### PR TITLE
Add custom sort order and config file param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,7 +570,15 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "regex",
+ "serde",
+ "serde_json",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -580,6 +594,37 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sharded-slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ rayon = "1.5"
 color-eyre = "0.6"
 eyre = "0.6"
 
+# json parsing
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.59"
+
 [dev-dependencies]
 pretty_assertions = "1.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,9 @@ pub struct Cli {
     #[clap(long, help = "When set, RustyWind will not delete duplicated classes")]
     allow_duplicates: bool,
 
+    #[clap(long, help = "When set, RustyWind will use the config file to derive configurations")]
+    config_file: Option<String>,
+
     #[clap(long, help = "When set, RustyWind will ignore this list of files")]
     ignored_files: Option<Vec<String>>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ pub struct Cli {
 
     #[clap(
         long,
-        help = "When set, RustyWind will use the config file to derive configurations.  The config file current only supports json with one property defaultSortOrder, e.g. { \"defaultSortOrder\": [\"class1\", ...] }"
+        help = "When set, RustyWind will use the config file to derive configurations.  The config file current only supports json with one property sortOrder, e.g. { \"sortOrder\": [\"class1\", ...] }"
     )]
     config_file: Option<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,10 @@ pub struct Cli {
     #[clap(long, help = "When set, RustyWind will not delete duplicated classes")]
     allow_duplicates: bool,
 
-    #[clap(long, help = "When set, RustyWind will use the config file to derive configurations.  The config file current only supports json with one property defaultSortOrder, e.g. { \"defaultSortOrder\": [\"class1\", ...] }")]
+    #[clap(
+        long,
+        help = "When set, RustyWind will use the config file to derive configurations.  The config file current only supports json with one property defaultSortOrder, e.g. { \"defaultSortOrder\": [\"class1\", ...] }"
+    )]
     config_file: Option<String>,
 
     #[clap(long, help = "When set, RustyWind will ignore this list of files")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ pub struct Cli {
     #[clap(long, help = "When set, RustyWind will not delete duplicated classes")]
     allow_duplicates: bool,
 
-    #[clap(long, help = "When set, RustyWind will use the config file to derive configurations")]
+    #[clap(long, help = "When set, RustyWind will use the config file to derive configurations.  The config file current only supports json with one property defaultSortOrder, e.g. { \"defaultSortOrder\": [\"class1\", ...] }")]
     config_file: Option<String>,
 
     #[clap(long, help = "When set, RustyWind will ignore this list of files")]

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,14 +1,14 @@
-use serde::{Deserialize};
 use eyre::{Context, Result};
 use ignore::WalkBuilder;
 use itertools::Itertools;
 use regex::Regex;
-use std::collections::HashSet;
+use serde::Deserialize;
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::fs;
 
 use crate::Cli;
 
@@ -36,7 +36,7 @@ pub enum Sorter {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ConfigFileContents {
-    default_sort_order: Vec<String>
+    default_sort_order: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -81,11 +81,15 @@ impl Options {
 fn get_sorter_from_cli(cli: &Cli) -> Result<Sorter> {
     match &cli.config_file {
         Some(config_file) => {
-            let file_contents = fs::read_to_string(config_file).expect("Error reading the config file");
-            let result:ConfigFileContents = serde_json::from_str(&file_contents).expect("Error while parsing the config file");
-            Ok(Sorter::CustomSorter(parse_custom_sorter(result.default_sort_order)))
+            let file_contents =
+                fs::read_to_string(config_file).expect("Error reading the config file");
+            let result: ConfigFileContents =
+                serde_json::from_str(&file_contents).expect("Error while parsing the config file");
+            Ok(Sorter::CustomSorter(parse_custom_sorter(
+                result.default_sort_order,
+            )))
         }
-        None => Ok(Sorter::DefaultSorter)
+        None => Ok(Sorter::DefaultSorter),
     }
 }
 
@@ -156,6 +160,6 @@ fn parse_custom_sorter(contents: Vec<String>) -> HashMap<String, usize> {
     contents
         .into_iter()
         .enumerate()
-        .map(|(index, class)| (class.to_string(), index))
+        .map(|(index, class)| (class, index))
         .collect()
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -83,10 +83,11 @@ fn get_sorter_from_cli(cli: &Cli) -> Result<Sorter> {
         Some(config_file) => {
             let file_contents =
                 fs::read_to_string(config_file).wrap_err("Error reading the config file");
-            let result: Result<ConfigFileContents> = serde_json::from_str(&file_contents?)
-                .wrap_err("Error while parsing the config file");
+            let config_file: ConfigFileContents = serde_json::from_str(&file_contents?)
+                .wrap_err("Error while parsing the config file")?;
+
             Ok(Sorter::CustomSorter(parse_custom_sorter(
-                result?.sort_order,
+                config_file.sort_order,
             )))
         }
         None => Ok(Sorter::DefaultSorter),

--- a/src/options.rs
+++ b/src/options.rs
@@ -36,7 +36,7 @@ pub enum Sorter {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ConfigFileContents {
-    default_sort_order: Vec<String>,
+    sort_order: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -82,11 +82,11 @@ fn get_sorter_from_cli(cli: &Cli) -> Result<Sorter> {
     match &cli.config_file {
         Some(config_file) => {
             let file_contents =
-                fs::read_to_string(config_file).expect("Error reading the config file");
-            let result: ConfigFileContents =
-                serde_json::from_str(&file_contents).expect("Error while parsing the config file");
+                fs::read_to_string(config_file).wrap_err("Error reading the config file");
+            let result: Result<ConfigFileContents> = serde_json::from_str(&file_contents?)
+                .wrap_err("Error while parsing the config file");
             Ok(Sorter::CustomSorter(parse_custom_sorter(
-                result.default_sort_order,
+                result?.sort_order,
             )))
         }
         None => Ok(Sorter::DefaultSorter),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -88,6 +88,7 @@ fn sort_classes_vec<'a>(classes: impl Iterator<Item = &'a str>, sorter:&HashMap<
             variants.remove(key).unwrap_or_default(),
             custom_classes,
             key.len() + 1,
+            sorter
         );
 
         sorted_variant_classes.append(&mut sorted_classes);
@@ -106,11 +107,12 @@ fn sort_variant_classes<'a>(
     classes: Vec<&'a str>,
     mut custom_classes: Vec<&'a str>,
     class_after: usize,
+    sorter: &HashMap<String, usize>
 ) -> (Vec<&'a str>, Vec<&'a str>) {
     let mut tailwind_classes = Vec::with_capacity(classes.len());
 
     for class in classes {
-        match class.get(class_after..).and_then(|class| SORTER.get(class)) {
+        match class.get(class_after..).and_then(|class| sorter.get(class)) {
             Some(class_placement) => tailwind_classes.push((class, class_placement)),
             None => custom_classes.push(class),
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use regex::Captures;
 
 use crate::consts::{VARIANTS, VARIANT_SEARCHER};
 use crate::defaults::{RE, SORTER};
-use crate::options::{FinderRegex, Sorter, Options};
+use crate::options::{FinderRegex, Options, Sorter};
 
 pub fn has_classes(file_contents: &str, options: &Options) -> bool {
     let regex = match &options.regex {
@@ -31,9 +31,9 @@ pub fn sort_file_contents<'a>(file_contents: &'a str, options: &Options) -> Cow<
 }
 
 fn sort_classes(class_string: &str, options: &Options) -> String {
-    let sorter:&HashMap<String, usize> = match &options.sorter {
+    let sorter: &HashMap<String, usize> = match &options.sorter {
         Sorter::DefaultSorter => &*SORTER,
-        Sorter::CustomSorter(custom_sorter) => custom_sorter
+        Sorter::CustomSorter(custom_sorter) => custom_sorter,
     };
 
     let str_vec = if options.allow_duplicates {
@@ -53,7 +53,10 @@ fn sort_classes(class_string: &str, options: &Options) -> String {
     string
 }
 
-fn sort_classes_vec<'a>(classes: impl Iterator<Item = &'a str>, sorter:&HashMap<String, usize>) -> Vec<&'a str> {
+fn sort_classes_vec<'a>(
+    classes: impl Iterator<Item = &'a str>,
+    sorter: &HashMap<String, usize>,
+) -> Vec<&'a str> {
     let enumerated_classes = classes.map(|class| ((class), sorter.get(class)));
 
     let mut tailwind_classes: Vec<(&str, &usize)> = vec![];
@@ -88,7 +91,7 @@ fn sort_classes_vec<'a>(classes: impl Iterator<Item = &'a str>, sorter:&HashMap<
             variants.remove(key).unwrap_or_default(),
             custom_classes,
             key.len() + 1,
-            sorter
+            sorter,
         );
 
         sorted_variant_classes.append(&mut sorted_classes);
@@ -107,7 +110,7 @@ fn sort_variant_classes<'a>(
     classes: Vec<&'a str>,
     mut custom_classes: Vec<&'a str>,
     class_after: usize,
-    sorter: &HashMap<String, usize>
+    sorter: &HashMap<String, usize>,
 ) -> (Vec<&'a str>, Vec<&'a str>) {
     let mut tailwind_classes = Vec::with_capacity(classes.len());
 


### PR DESCRIPTION
Awesome project!  This PR adds the ability to define a custom sort order in a config file that the user can optionally provide.  This came up with our own usage to have a custom sorter.  I tried to keep the same naming convention as headwind. 

I think it would be nice in the future to do something similar to prettier where you can define with more granularity how the config file is parsed, what the defaults are (e.g. maybe an optional `.rustywindrc` in each project like `.prettierrc`) as well as what precidence is has.

Anyway feel free to reject this PR if it doesn't match the direction you want to go with the project.

Example call: `rustywind --config-file .rustywind ...`
Example json file:
```json
{
    "sortOrder": [
        "container",
        "static",
        "..."
    ]
}
```