### PR TITLE
Approach a fix for no `\n` at the end of a file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -121,9 +121,9 @@ fn main() -> Result<()> {
 
         if utils::has_classes(&contents, &options) {
             let sorted_content = utils::sort_file_contents(&contents, &options);
-            print!("{}", sorted_content);
+            println!("{}", sorted_content);
         } else {
-            print!("{}", contents);
+            println!("{}", contents);
             eprint!("[WARN] No classes were found in STDIN");
         }
     } else {


### PR DESCRIPTION
This should fix the issue with the absence of an `\n` when `--stdin` is used. It should hopefully fix this issue; https://github.com/avencera/rustywind/issues/62