### PR TITLE
Fix Regex to only match the characters selected (and work with conditionals)

### DIFF
--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 use std::collections::HashMap;
 
 pub static RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"\b(?:class(?:Name)*\s*=\s*["'])([_a-zA\.-Z0-9\s\-:\[\]]+)["']"#).unwrap()
+    Regex::new(r#"\b(?:class(?:Name)*\s*=\s*["'])([_a-zA-Z0-9\.\s\-:\[\]]+)["']"#).unwrap()
 });
 
 pub static SORTER: Lazy<HashMap<String, usize>> = Lazy::new(|| {


### PR DESCRIPTION
> `\.-Z` matches a single character in the range between . (index 46) and Z (index 90) (case sensitive)

Relates to problem with conditionals. #44 