### PR TITLE
Add `quiet` mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,9 @@ pub struct Cli {
     /// Uses a custom regex instead of default one.
     #[arg(long)]
     custom_regex: Option<String>,
+    /// Do not print log messages
+    #[arg(long, default_value = "false", conflicts_with_all = &["dry_run"])]
+    quiet: bool,
 }
 
 fn main() -> Result<()> {
@@ -105,7 +108,9 @@ fn main() -> Result<()> {
         ),
 
         WriteMode::ToFile => {
-            println!("\nwrite mode is active the following files are being saved:");
+            if !options.quiet {
+                println!("\nwrite mode is active the following files are being saved:");
+            }
         }
 
         WriteMode::ToConsole => println!(
@@ -210,7 +215,9 @@ fn write_to_file(file_path: &Path, sorted_contents: &str, options: &Options) {
 }
 
 fn print_file_name(file_path: &Path, options: &Options) {
-    println!("  * {}", get_file_name(file_path, &options.starting_paths));
+    if !options.quiet {
+        println!("  * {}", get_file_name(file_path, &options.starting_paths));
+    }
 }
 
 fn get_file_name(file_path: &Path, starting_paths: &[PathBuf]) -> String {

--- a/src/options.rs
+++ b/src/options.rs
@@ -53,6 +53,7 @@ pub struct Options {
     pub allow_duplicates: bool,
     pub search_paths: Vec<PathBuf>,
     pub ignored_files: HashSet<PathBuf>,
+    pub quiet: bool,
 }
 
 impl Options {
@@ -78,6 +79,7 @@ impl Options {
             sorter: get_sorter_from_cli(&cli)?,
             allow_duplicates: cli.allow_duplicates,
             ignored_files: get_ignored_files_from_cli(&cli),
+            quiet: cli.quiet,
         })
     }
 }


### PR DESCRIPTION
Hi.

I think sometimes the log message is too verbose. So I added this `quite` mode.

```bash
rustywind on  quiet-mode is 📦 v0.19.0 via 🦀 v1.73.0 took 2s
🦄 cargo run -- /home/user/playground/kertas --write --quiet

rustywind on  quiet-mode is 📦 v0.19.0 via 🦀 v1.73.0
🦄 cargo run -- /home/user/playground/kertas --write

write mode is active the following files are being saved:
  * kertas/src/error_template.rs
  * kertas/src/routes/about.rs
  * kertas/posts/blog/test.md
  * kertas/src/components/footer.rs
  * kertas/src/components/error.rs
  * kertas/src/components/post.rs
  * kertas/src/routes/home.rs
```

Questions:

- Should I keep `conflicts_with_all = &["dry_run"]` or remove it? 