### PR TITLE
feat: make the `sort_classes` function public

### DIFF
--- a/rustywind-core/src/sorter.rs
+++ b/rustywind-core/src/sorter.rs
@@ -66,26 +66,14 @@ pub fn sort_file_contents<'a>(file_contents: &'a str, options: &Options) -> Cow<
 }
 
 fn sort_classes(class_string: &str, options: &Options) -> String {
-    let sorter: &HashMap<String, usize> = match &options.sorter {
-        Sorter::DefaultSorter => &SORTER,
-        Sorter::CustomSorter(custom_sorter) => custom_sorter,
-    };
+    let sorter = options.extract_sorter();
 
-    let str_vec = if options.allow_duplicates {
+    if options.allow_duplicates {
         sort_classes_vec(class_string.split_ascii_whitespace(), sorter)
     } else {
         sort_classes_vec(class_string.split_ascii_whitespace().unique(), sorter)
-    };
-
-    let mut string = String::with_capacity(str_vec.len() * 2);
-
-    for str in str_vec {
-        string.push_str(str);
-        string.push(' ')
     }
-
-    string.pop();
-    string
+    .join(" ")
 }
 
 fn sort_classes_vec<'a>(

--- a/rustywind-core/src/sorter.rs
+++ b/rustywind-core/src/sorter.rs
@@ -65,7 +65,9 @@ pub fn sort_file_contents<'a>(file_contents: &'a str, options: &Options) -> Cow<
         })
 }
 
-fn sort_classes(class_string: &str, options: &Options) -> String {
+/// Given a [&str] of whitespace-separated classes, returns a [String] of sorted classes.
+/// Does not preserve whitespace.
+pub fn sort_classes(class_string: &str, options: &Options) -> String {
     let sorter = options.extract_sorter();
 
     if options.allow_duplicates {


### PR DESCRIPTION
Requested by @bram209 [here](https://github.com/bram209/leptosfmt/issues/116#issuecomment-2129739696), and they do have a point.

I also made some other minor refactors, and included 2 utility methods on the `Options` struct. If you don't want those, or there's any other issues, let me know and I can make whatever changes are required.