### PR TITLE
Update class regex

### DIFF
--- a/rustywind-core/src/sorter.rs
+++ b/rustywind-core/src/sorter.rs
@@ -13,7 +13,7 @@ use crate::defaults::{RE, SORTER};
 use eyre::Result;
 
 pub(crate) static SORTER_EXTRACTOR_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^(\.[^\s]+)[ ]").unwrap());
+    Lazy::new(|| Regex::new(r"^\s*(\.[^\s]+)[ ]").unwrap());
 
 /// Use either our default regex in [crate::defaults::RE] or a custom regex.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Changes the regex that selects classes in a css file to ignore any leading whitespace.

This is useful for when you have whitespace before a class declaration, like a @layer directive.

## Before, using `^(\.[^\s]+)[ ]`
```css
// output.css
@layer utilities {
  .visible { // ❌ does not match .visible due to leading whitespace :-(
    visibility: visible;
  }
}
```
## After, using `^\s*(\.[^\s]+)[ ]` instead
```css
// output.css
@layer utilities {
  .visible { // ✅ matches!
    visibility: visible;
  }
}
```