### PR TITLE
Add Tailwind prefix sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [0.25.0-rc.1] - 2026-06-10
+
+### Added
+
+- Add `--tailwind-prefix` support for Tailwind v3 (`tw-`) and v4 (`tw:`)
+  prefix styles while preserving original class strings in output
+
+### Breaking changes
+
+- `RustyWind` now includes a `tailwind_prefix` option. Code constructing
+  `RustyWind` with a struct literal must set `tailwind_prefix: None` or use
+  `RustyWind::new`.
+- `PatternSorter` is no longer a unit struct. Use `PatternSorter::new()` or
+  `PatternSorter::default()`.
+- For prefix-aware sorters, `SortKey.class` stores the normalized class used for
+  sorting rather than the original prefixed input.
+
 ## [0.25.0-alpha.1] - 2026-05-30
 
 ### Tailwind v4 support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,7 +1601,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustywind"
-version = "0.25.0-alpha.1"
+version = "0.25.0-rc.1"
 dependencies = [
  "ahash",
  "anstyle",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "rustywind_core"
-version = "0.4.0-alpha.1"
+version = "0.4.0-rc.1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "rustywind_vite"
-version = "0.4.0-alpha.1"
+version = "0.4.0-rc.1"
 dependencies = [
  "color-eyre",
  "eyre",

--- a/npm/packages/darwin-arm64/package.json
+++ b/npm/packages/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustywind-darwin-arm64",
-  "version": "0.25.0-alpha.1",
+  "version": "0.25.0-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/avencera/rustywind.git"

--- a/npm/packages/darwin-x64/package.json
+++ b/npm/packages/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustywind-darwin-x64",
-  "version": "0.25.0-alpha.1",
+  "version": "0.25.0-rc.1",
   "license": "MIT",
   "cpu": [
     "x64"

--- a/npm/packages/linux-arm-gnueabihf/package.json
+++ b/npm/packages/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustywind-linux-arm-gnueabihf",
-  "version": "0.25.0-alpha.1",
+  "version": "0.25.0-rc.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/avencera/rustywind.git"

--- a/npm/packages/linux-arm64-gnu/package.json
+++ b/npm/packages/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustywind-linux-arm64-gnu",
-  "version": "0.25.0-alpha.1",
+  "version": "0.25.0-rc.1",
   "cpu": [
     "arm64"
   ],

--- a/npm/packages/linux-arm64-musl/package.json
+++ b/npm/packages/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustywind-linux-arm64-musl",
-  "version": "0.25.0-alpha.1",
+  "version": "0.25.0-rc.1",
   "preferUnplugged": true,
   "os": [
     "linux"

--- a/npm/packages/linux-x64-musl/package.json
+++ b/npm/packages/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustywind-linux-x64-musl",
-  "version": "0.25.0-alpha.1",
+  "version": "0.25.0-rc.1",
   "cpu": [
     "x64"
   ],

--- a/npm/packages/rustywind/package.json
+++ b/npm/packages/rustywind/package.json
@@ -1,15 +1,15 @@
 {
   "name": "rustywind",
-  "version": "0.25.0-alpha.1",
+  "version": "0.25.0-rc.1",
   "optionalDependencies": {
-    "rustywind-win32-x64-msvc": "0.25.0-alpha.1",
-    "rustywind-linux-arm-gnueabihf": "0.25.0-alpha.1",
-    "rustywind-linux-arm64-gnu": "0.25.0-alpha.1",
-    "rustywind-darwin-x64": "0.25.0-alpha.1",
-    "rustywind-linux-arm64-musl": "0.25.0-alpha.1",
-    "rustywind-darwin-arm64": "0.25.0-alpha.1",
-    "rustywind-linux-x64-musl": "0.25.0-alpha.1",
-    "rustywind-win32-ia32-msvc": "0.25.0-alpha.1"
+    "rustywind-win32-x64-msvc": "0.25.0-rc.1",
+    "rustywind-linux-arm-gnueabihf": "0.25.0-rc.1",
+    "rustywind-linux-arm64-gnu": "0.25.0-rc.1",
+    "rustywind-darwin-x64": "0.25.0-rc.1",
+    "rustywind-linux-arm64-musl": "0.25.0-rc.1",
+    "rustywind-darwin-arm64": "0.25.0-rc.1",
+    "rustywind-linux-x64-musl": "0.25.0-rc.1",
+    "rustywind-win32-ia32-msvc": "0.25.0-rc.1"
   },
   "bugs": {
     "url": "https://github.com/avencera/rustywind/issues"

--- a/npm/packages/win32-ia32-msvc/package.json
+++ b/npm/packages/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustywind-win32-ia32-msvc",
-  "version": "0.25.0-alpha.1",
+  "version": "0.25.0-rc.1",
   "license": "MIT",
   "os": [
     "win32"

--- a/npm/packages/win32-x64-msvc/package.json
+++ b/npm/packages/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustywind-win32-x64-msvc",
-  "version": "0.25.0-alpha.1",
+  "version": "0.25.0-rc.1",
   "cpu": [
     "x64"
   ],

--- a/rustywind-cli/Cargo.toml
+++ b/rustywind-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustywind"
-version = "0.25.0-alpha.1"
+version = "0.25.0-rc.1"
 description = "A CLI to sort tailwind CSS classes"
 documentation = "https://docs.rs/rustywind"
 authors.workspace = true
@@ -16,8 +16,8 @@ pkg-fmt = "tgz"
 
 [dependencies]
 # rustywind
-rustywind_core = { path = "../rustywind-core", version = "=0.4.0-alpha.1" }
-rustywind_vite = { path = "../rustywind-vite", version = "=0.4.0-alpha.1" }
+rustywind_core = { path = "../rustywind-core", version = "=0.4.0-rc.1" }
+rustywind_vite = { path = "../rustywind-vite", version = "=0.4.0-rc.1" }
 
 # utils
 regex = { workspace = true }

--- a/rustywind-cli/src/main.rs
+++ b/rustywind-cli/src/main.rs
@@ -93,7 +93,7 @@ pub struct Cli {
     /// Specify how individual classes are wrapped.
     #[arg(long)]
     class_wrapping: Option<options::CliClassWrapping>,
-    /// Tailwind prefix to ignore while sorting classes, e.g. tw for tw: or tw- classes.
+    /// Tailwind prefix used when sorting classes, e.g. tw for tw: or tw- classes.
     #[arg(long)]
     tailwind_prefix: Option<String>,
     /// Do not print log messages

--- a/rustywind-cli/src/main.rs
+++ b/rustywind-cli/src/main.rs
@@ -93,6 +93,9 @@ pub struct Cli {
     /// Specify how individual classes are wrapped.
     #[arg(long)]
     class_wrapping: Option<options::CliClassWrapping>,
+    /// Tailwind prefix to ignore while sorting classes, e.g. tw for tw: or tw- classes.
+    #[arg(long)]
+    tailwind_prefix: Option<String>,
     /// Do not print log messages
     #[arg(long, default_value = "false", conflicts_with_all = &["dry_run"])]
     quiet: bool,

--- a/rustywind-cli/src/options.rs
+++ b/rustywind-cli/src/options.rs
@@ -81,6 +81,7 @@ impl Options {
             sorter: get_sorter_from_cli(&cli)?,
             allow_duplicates: cli.allow_duplicates,
             class_wrapping: get_class_wrapping_from_cli(&cli),
+            tailwind_prefix: cli.tailwind_prefix.clone(),
         };
 
         Ok(Options {

--- a/rustywind-core/CHANGELOG.md
+++ b/rustywind-core/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.4.0-rc.1] - 2026-06-10
+
+### Added
+
+- Add Tailwind prefix-aware sorting for Tailwind v3 (`tw-`) and v4 (`tw:`)
+  prefix styles while preserving original class strings in output
+
+### Breaking changes
+
+- `RustyWind` now includes a `tailwind_prefix` option. Code constructing
+  `RustyWind` with a struct literal must set `tailwind_prefix: None` or use
+  `RustyWind::new`.
+- `PatternSorter` is no longer a unit struct. Use `PatternSorter::new()` or
+  `PatternSorter::default()`.
+- For prefix-aware sorters, `SortKey.class` stores the normalized class used for
+  sorting rather than the original prefixed input.
+
 ## [0.3.1] - 2025-08-07
 
 - Fix class extraction regex, [#119](https://github.com/avencera/rustywind/pull/119), thanks [@5need](https://github.com/5need)

--- a/rustywind-core/Cargo.toml
+++ b/rustywind-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustywind_core"
-version = "0.4.0-alpha.1"
+version = "0.4.0-rc.1"
 description = "A library for sorting tailwind CSS classes"
 documentation = "https://docs.rs/rustywind_core"
 authors.workspace = true

--- a/rustywind-core/src/app.rs
+++ b/rustywind-core/src/app.rs
@@ -5,14 +5,22 @@ use crate::{
     consts::{VARIANT_SEARCHER, VARIANTS},
     hybrid_sorter::HybridSorter,
     sorter::{FinderRegex, Sorter},
+    tailwind_prefix::{normalize_tailwind_prefix, normalize_tailwind_prefix_value},
 };
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use aho_corasick::{Anchored, Input};
 use regex::Captures;
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock, RwLock};
 
 /// Global instance of the HybridSorter for pattern-based sorting.
 static PATTERN_SORTER: LazyLock<HybridSorter> = LazyLock::new(HybridSorter::new);
+static PREFIXED_PATTERN_SORTERS: LazyLock<RwLock<HashMap<String, Arc<HybridSorter>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+struct SortCandidate<'a> {
+    original: &'a str,
+    lookup: Cow<'a, str>,
+}
 
 /// The options to pass to the sorter.
 #[derive(Debug, Clone)]
@@ -21,6 +29,7 @@ pub struct RustyWind {
     pub sorter: Sorter,
     pub allow_duplicates: bool,
     pub class_wrapping: ClassWrapping,
+    pub tailwind_prefix: Option<String>,
 }
 
 impl Default for RustyWind {
@@ -30,6 +39,7 @@ impl Default for RustyWind {
             sorter: Sorter::PatternSorter,
             allow_duplicates: false,
             class_wrapping: ClassWrapping::NoWrapping,
+            tailwind_prefix: None,
         }
     }
 }
@@ -41,11 +51,22 @@ impl RustyWind {
         allow_duplicates: bool,
         class_wrapping: ClassWrapping,
     ) -> Self {
+        Self::new_with_tailwind_prefix(regex, sorter, allow_duplicates, class_wrapping, None)
+    }
+
+    pub fn new_with_tailwind_prefix(
+        regex: FinderRegex,
+        sorter: Sorter,
+        allow_duplicates: bool,
+        class_wrapping: ClassWrapping,
+        tailwind_prefix: Option<String>,
+    ) -> Self {
         Self {
             regex,
             sorter,
             allow_duplicates,
             class_wrapping,
+            tailwind_prefix,
         }
     }
 
@@ -117,27 +138,41 @@ impl RustyWind {
         // use pattern-based sorting if PatternSorter is selected
         if matches!(self.sorter, Sorter::PatternSorter) {
             let classes_vec: Vec<&str> = classes.collect();
+            if let Some(tailwind_prefix) = self
+                .tailwind_prefix
+                .as_deref()
+                .and_then(normalize_tailwind_prefix_value)
+            {
+                return prefixed_pattern_sorter(tailwind_prefix).sort_classes(&classes_vec);
+            }
             return PATTERN_SORTER.sort_classes(&classes_vec);
         }
 
         // otherwise, use the old HashMap-based approach
-        let enumerated_classes = classes.map(|class| ((class), self.sorter.get(class)));
+        let candidates = classes.map(|class| SortCandidate {
+            original: class,
+            lookup: normalize_tailwind_prefix(class, self.tailwind_prefix.as_deref()),
+        });
 
         let mut tailwind_classes: Vec<(&str, &usize)> = vec![];
         let mut custom_classes: Vec<&str> = vec![];
-        let mut variants: HashMap<&str, Vec<&str>> = HashMap::new();
+        let mut variants: HashMap<&str, Vec<SortCandidate>> = HashMap::new();
 
-        for (class, maybe_size) in enumerated_classes {
-            match maybe_size {
-                Some(size) => tailwind_classes.push((class, size)),
+        for candidate in candidates {
+            match self
+                .sorter
+                .get(candidate.original)
+                .or_else(|| self.sorter.get(candidate.lookup.as_ref()))
+            {
+                Some(size) => tailwind_classes.push((candidate.original, size)),
                 None => {
-                    let input = Input::new(class).anchored(Anchored::Yes);
+                    let input = Input::new(candidate.lookup.as_ref()).anchored(Anchored::Yes);
                     match VARIANT_SEARCHER.find(input) {
                         Some(prefix_match) => {
                             let prefix = VARIANTS[prefix_match.pattern()];
-                            variants.entry(prefix).or_default().push(class)
+                            variants.entry(prefix).or_default().push(candidate)
                         }
-                        None => custom_classes.push(class),
+                        None => custom_classes.push(candidate.original),
                     }
                 }
             }
@@ -173,19 +208,42 @@ impl RustyWind {
 
     fn sort_variant_classes<'a>(
         &self,
-        classes: Vec<&'a str>,
+        classes: Vec<SortCandidate<'a>>,
         mut custom_classes: Vec<&'a str>,
         class_after: usize,
     ) -> (Vec<&'a str>, Vec<&'a str>) {
         let mut tailwind_classes = Vec::with_capacity(classes.len());
 
-        for class in classes {
-            match class
+        for candidate in classes {
+            let normalized_remainder = candidate.lookup.get(class_after..);
+            let v4_original_remainder = self
+                .tailwind_prefix
+                .as_deref()
+                .and_then(normalize_tailwind_prefix_value)
+                .and_then(|prefix| {
+                    candidate
+                        .original
+                        .strip_prefix(prefix)
+                        .and_then(|rest| rest.strip_prefix(':'))
+                        .zip(normalized_remainder)
+                        .map(|(_, normalized_remainder)| format!("{prefix}:{normalized_remainder}"))
+                });
+
+            match candidate
+                .original
                 .get(class_after..)
                 .and_then(|class| self.sorter.get(class))
+                .or_else(|| {
+                    v4_original_remainder
+                        .as_deref()
+                        .and_then(|class| self.sorter.get(class))
+                })
+                .or_else(|| normalized_remainder.and_then(|class| self.sorter.get(class)))
             {
-                Some(class_placement) => tailwind_classes.push((class, class_placement)),
-                None => custom_classes.push(class),
+                Some(class_placement) => {
+                    tailwind_classes.push((candidate.original, class_placement))
+                }
+                None => custom_classes.push(candidate.original),
             }
         }
 
@@ -198,6 +256,30 @@ impl RustyWind {
 
         (sorted_classes, custom_classes)
     }
+}
+
+fn prefixed_pattern_sorter(tailwind_prefix: &str) -> Arc<HybridSorter> {
+    if let Some(sorter) = PREFIXED_PATTERN_SORTERS
+        .read()
+        .expect("prefixed pattern sorter cache should not be poisoned")
+        .get(tailwind_prefix)
+    {
+        return Arc::clone(sorter);
+    }
+
+    let mut sorters = PREFIXED_PATTERN_SORTERS
+        .write()
+        .expect("prefixed pattern sorter cache should not be poisoned");
+
+    Arc::clone(
+        sorters
+            .entry(tailwind_prefix.to_string())
+            .or_insert_with(|| {
+                Arc::new(HybridSorter::new_with_tailwind_prefix(Some(
+                    tailwind_prefix,
+                )))
+            }),
+    )
 }
 
 fn split_class_tokens(class_string: &str) -> Vec<&str> {
@@ -248,6 +330,7 @@ mod tests {
         sorter: Sorter::PatternSorter,
         allow_duplicates: false,
         class_wrapping: ClassWrapping::NoWrapping,
+        tailwind_prefix: None,
     };
 
     // HAS_CLASSES --------------------------------------------------------------------------------
@@ -352,6 +435,7 @@ mod tests {
             allow_duplicates: true,
             regex: FinderRegex::DefaultRegex,
             class_wrapping: ClassWrapping::NoWrapping,
+            tailwind_prefix: None,
         };
 
         let input = r#"<div class="flex flex m-4 m-4"></div>"#;
@@ -610,6 +694,7 @@ mod tests {
             sorter: Sorter::PatternSorter,
             allow_duplicates: false,
             class_wrapping,
+            tailwind_prefix: None,
         };
 
         assert_eq!(app.sort_file_contents(input), output);

--- a/rustywind-core/src/app.rs
+++ b/rustywind-core/src/app.rs
@@ -224,9 +224,9 @@ impl RustyWind {
                     candidate
                         .original
                         .strip_prefix(prefix)
-                        .and_then(|rest| rest.strip_prefix(':'))
-                        .zip(normalized_remainder)
-                        .map(|(_, normalized_remainder)| format!("{prefix}:{normalized_remainder}"))
+                        .and_then(|rest| rest.strip_prefix(':'))?;
+                    normalized_remainder
+                        .map(|normalized_remainder| format!("{prefix}:{normalized_remainder}"))
                 });
 
             match candidate

--- a/rustywind-core/src/hybrid_sorter.rs
+++ b/rustywind-core/src/hybrid_sorter.rs
@@ -48,6 +48,11 @@ impl HybridSorter {
         Self::with_cache_size(DEFAULT_CACHE_SIZE)
     }
 
+    /// Create a new hybrid sorter that understands a configured Tailwind prefix.
+    pub fn new_with_tailwind_prefix(tailwind_prefix: Option<&str>) -> Self {
+        Self::with_cache_size_and_tailwind_prefix(DEFAULT_CACHE_SIZE, tailwind_prefix)
+    }
+
     /// Create a new hybrid sorter with custom cache size
     ///
     /// # Arguments
@@ -63,8 +68,16 @@ impl HybridSorter {
     /// let sorter = HybridSorter::with_cache_size(25_000);
     /// ```
     pub fn with_cache_size(cache_size: usize) -> Self {
+        Self::with_cache_size_and_tailwind_prefix(cache_size, None)
+    }
+
+    /// Create a new hybrid sorter with custom cache size and Tailwind prefix.
+    pub fn with_cache_size_and_tailwind_prefix(
+        cache_size: usize,
+        tailwind_prefix: Option<&str>,
+    ) -> Self {
         Self {
-            pattern_sorter: PatternSorter::new(),
+            pattern_sorter: PatternSorter::new_with_tailwind_prefix(tailwind_prefix),
             cache: Arc::new(Cache::new(cache_size)),
         }
     }
@@ -105,7 +118,7 @@ impl HybridSorter {
         if let Some(sort_key) = self.pattern_sorter.get_sort_key(class) {
             // cache the computed result for future lookups
             // CompactString stores most classes inline (24 bytes) avoiding heap allocations
-            self.cache.insert(sort_key.class.clone(), sort_key.clone());
+            self.cache.insert(class_compact, sort_key.clone());
             return Some(sort_key);
         }
 

--- a/rustywind-core/src/lib.rs
+++ b/rustywind-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod consts;
 pub mod defaults;
 pub mod parser;
 pub mod sorter;
+pub mod tailwind_prefix;
 
 // Pattern-based sorting modules
 pub mod class_parser;

--- a/rustywind-core/src/pattern_sorter.rs
+++ b/rustywind-core/src/pattern_sorter.rs
@@ -30,6 +30,7 @@ use std::cmp::Ordering;
 
 use crate::class_parser::parse_class;
 use crate::property_order::get_property_index;
+use crate::tailwind_prefix::{normalize_tailwind_prefix, normalize_tailwind_prefix_value};
 use crate::variant_order::{
     ARBITRARY_VARIANT_BIT, VariantInfo, calculate_variant_order, compare_variant_lists,
     parse_variants,
@@ -540,7 +541,7 @@ pub struct SortKey {
     /// Number of properties this utility generates
     pub property_count: usize,
 
-    /// Original class string (for alphabetical tiebreaker)
+    /// Class string used for sorting and alphabetical tiebreaks
     /// Uses CompactString for memory efficiency (24 bytes inline, no heap for typical classes)
     pub class: compact_str::CompactString,
 
@@ -1139,12 +1140,25 @@ impl PartialOrd for SortKey {
 ///
 /// This struct provides methods to generate sort keys for classes and sort
 /// collections of classes according to Tailwind's canonical ordering.
-pub struct PatternSorter;
+pub struct PatternSorter {
+    tailwind_prefix: Option<compact_str::CompactString>,
+}
 
 impl PatternSorter {
     /// Create a new pattern sorter.
     pub fn new() -> Self {
-        Self
+        Self {
+            tailwind_prefix: None,
+        }
+    }
+
+    /// Create a new pattern sorter that understands a configured Tailwind prefix.
+    pub fn new_with_tailwind_prefix(tailwind_prefix: Option<&str>) -> Self {
+        Self {
+            tailwind_prefix: tailwind_prefix
+                .and_then(normalize_tailwind_prefix_value)
+                .map(compact_str::CompactString::new),
+        }
     }
 
     /// Get the sort key for a class string.
@@ -1167,8 +1181,10 @@ impl PatternSorter {
     /// assert!(key.variant_order > 0);
     /// ```
     pub fn get_sort_key(&self, class: &str) -> Option<SortKey> {
+        let sort_class = normalize_tailwind_prefix(class, self.tailwind_prefix.as_deref());
+
         // parse the class
-        let parsed = parse_class(class)?;
+        let parsed = parse_class(&sort_class)?;
 
         // calculate variant order using bitwise flags
         let variant_order = calculate_variant_order(&parsed.variants);
@@ -1205,17 +1221,17 @@ impl PatternSorter {
 
         // count how many CSS declarations this utility generates
         // use the real declaration count from Tailwind (not just property count)
-        let property_count = crate::utility_map::get_declaration_count(class);
+        let property_count = crate::utility_map::get_declaration_count(&sort_class);
 
         // extract numeric value for value-based sub-sorting
-        let numeric_value = extract_numeric_value(class);
+        let numeric_value = extract_numeric_value(&sort_class);
 
         // check if this is a negative value utility
-        let is_negative = is_negative_value(class);
+        let is_negative = is_negative_value(&sort_class);
 
         // use CompactString for memory efficiency (24 bytes inline storage)
         // most Tailwind classes fit within 24 bytes avoiding heap allocation entirely
-        let class_compact = compact_str::CompactString::new(class);
+        let class_compact = compact_str::CompactString::new(sort_class.as_ref());
 
         // check if this class contains bare group/peer variants (invalid in Tailwind)
         let is_unparseable = has_bare_group_or_peer(&variant_chain);

--- a/rustywind-core/src/tailwind_prefix.rs
+++ b/rustywind-core/src/tailwind_prefix.rs
@@ -1,0 +1,157 @@
+use std::borrow::Cow;
+
+/// Normalize a Tailwind-prefixed class into the class name used for sorting.
+///
+/// Tailwind v3 places the prefix on the utility (`md:tw-text-lg`), while v4
+/// places it as the first variant-like segment (`tw:md:text-lg`). The returned
+/// value is only used to compute sort keys; callers should keep the original
+/// class string for output.
+pub fn normalize_tailwind_prefix<'a>(class: &'a str, prefix: Option<&str>) -> Cow<'a, str> {
+    let Some(prefix) = prefix.and_then(normalize_tailwind_prefix_value) else {
+        return Cow::Borrowed(class);
+    };
+
+    if let Some(rest) = class
+        .strip_prefix(prefix)
+        .and_then(|rest| rest.strip_prefix(':'))
+        && !rest.is_empty()
+    {
+        return Cow::Borrowed(rest);
+    }
+
+    let utility_start = utility_start(class);
+    let (variants, utility) = class.split_at(utility_start);
+
+    match normalize_v3_utility(utility, prefix) {
+        Some(Cow::Borrowed(utility)) if variants.is_empty() => Cow::Borrowed(utility),
+        Some(utility) => Cow::Owned(format!("{variants}{utility}")),
+        None => Cow::Borrowed(class),
+    }
+}
+
+pub(crate) fn normalize_tailwind_prefix_value(prefix: &str) -> Option<&str> {
+    let prefix = prefix.trim_end_matches(['-', ':']);
+    (!prefix.is_empty()).then_some(prefix)
+}
+
+fn utility_start(class: &str) -> usize {
+    let mut start = 0;
+    let mut bracket_depth: u32 = 0;
+
+    for (index, character) in class.char_indices() {
+        match character {
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            ':' if bracket_depth == 0 => start = index + 1,
+            _ => {}
+        }
+    }
+
+    start
+}
+
+fn normalize_v3_utility<'a>(utility: &'a str, prefix: &str) -> Option<Cow<'a, str>> {
+    let (important, utility) = utility
+        .strip_prefix('!')
+        .map_or(("", utility), |utility| ("!", utility));
+    let prefixed = format!("{prefix}-");
+
+    if let Some(rest) = utility.strip_prefix(&prefixed) {
+        return Some(with_important_prefix(important, rest));
+    }
+
+    if let Some(rest) = utility
+        .strip_prefix('-')
+        .and_then(|utility| utility.strip_prefix(&prefixed))
+    {
+        return Some(Cow::Owned(format!("{important}-{rest}")));
+    }
+
+    None
+}
+
+fn with_important_prefix<'a>(important: &str, utility: &'a str) -> Cow<'a, str> {
+    if important.is_empty() {
+        Cow::Borrowed(utility)
+    } else {
+        Cow::Owned(format!("{important}{utility}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_tailwind_prefix;
+
+    #[test]
+    fn normalizes_tailwind_v3_prefixes() {
+        assert_eq!(
+            normalize_tailwind_prefix("tw-text-xl", Some("tw")),
+            "text-xl"
+        );
+        assert_eq!(
+            normalize_tailwind_prefix("md:tw-text-xl", Some("tw")),
+            "md:text-xl"
+        );
+        assert_eq!(
+            normalize_tailwind_prefix("hover:-tw-mr-4", Some("tw")),
+            "hover:-mr-4"
+        );
+    }
+
+    #[test]
+    fn normalizes_tailwind_v4_prefixes() {
+        assert_eq!(
+            normalize_tailwind_prefix("tw:text-xl", Some("tw")),
+            "text-xl"
+        );
+        assert_eq!(
+            normalize_tailwind_prefix("tw:md:text-xl", Some("tw")),
+            "md:text-xl"
+        );
+        assert_eq!(
+            normalize_tailwind_prefix("tw:hover:-mr-4", Some("tw")),
+            "hover:-mr-4"
+        );
+    }
+
+    #[test]
+    fn supports_dash_suffix_in_configured_prefix() {
+        assert_eq!(
+            normalize_tailwind_prefix("md:tw-text-xl", Some("tw-")),
+            "md:text-xl"
+        );
+        assert_eq!(
+            normalize_tailwind_prefix("tw:md:text-xl", Some("tw-")),
+            "md:text-xl"
+        );
+    }
+
+    #[test]
+    fn preserves_important_modifiers() {
+        assert_eq!(
+            normalize_tailwind_prefix("hover:!tw-bg-red-500", Some("tw")),
+            "hover:!bg-red-500"
+        );
+        assert_eq!(
+            normalize_tailwind_prefix("hover:!-tw-mr-4", Some("tw")),
+            "hover:!-mr-4"
+        );
+    }
+
+    #[test]
+    fn ignores_colons_inside_arbitrary_variants() {
+        assert_eq!(
+            normalize_tailwind_prefix("[&:hover]:tw-bg-red-500", Some("tw")),
+            "[&:hover]:bg-red-500"
+        );
+    }
+
+    #[test]
+    fn leaves_unprefixed_classes_unchanged() {
+        assert_eq!(
+            normalize_tailwind_prefix("md:text-xl", Some("tw")),
+            "md:text-xl"
+        );
+        assert_eq!(normalize_tailwind_prefix("tw-text-xl", None), "tw-text-xl");
+    }
+}

--- a/rustywind-core/tests/test_tailwind_prefix.rs
+++ b/rustywind-core/tests/test_tailwind_prefix.rs
@@ -1,0 +1,152 @@
+use rustywind_core::RustyWind;
+use rustywind_core::hybrid_sorter::HybridSorter;
+use rustywind_core::sorter::{FinderRegex, Sorter};
+use rustywind_core::tailwind_prefix::normalize_tailwind_prefix;
+
+fn normalize_all(classes: Vec<&str>, prefix: &str) -> Vec<String> {
+    classes
+        .into_iter()
+        .map(|class| normalize_tailwind_prefix(class, Some(prefix)).into_owned())
+        .collect()
+}
+
+#[test]
+fn tailwind_v3_prefixed_classes_sort_like_unprefixed_classes() {
+    let prefixed_sorter = HybridSorter::new_with_tailwind_prefix(Some("tw"));
+    let normal_sorter = HybridSorter::new();
+
+    let prefixed = vec![
+        "md:tw-text-xl",
+        "tw-p-4",
+        "hover:-tw-mr-4",
+        "tw-bg-white",
+        "tw-flex",
+    ];
+    let unprefixed = vec!["md:text-xl", "p-4", "hover:-mr-4", "bg-white", "flex"];
+
+    let sorted_prefixed = prefixed_sorter.sort_classes(&prefixed);
+    let sorted_unprefixed = normal_sorter.sort_classes(&unprefixed);
+
+    assert_eq!(
+        normalize_all(sorted_prefixed.clone(), "tw"),
+        sorted_unprefixed
+    );
+    assert!(sorted_prefixed.iter().any(|class| class.starts_with("tw-")));
+    assert!(sorted_prefixed.iter().any(|class| class.contains(":tw-")));
+}
+
+#[test]
+fn tailwind_v4_prefixed_classes_sort_like_unprefixed_classes() {
+    let prefixed_sorter = HybridSorter::new_with_tailwind_prefix(Some("tw"));
+    let normal_sorter = HybridSorter::new();
+
+    let prefixed = vec![
+        "tw:md:text-xl",
+        "tw:p-4",
+        "tw:hover:-mr-4",
+        "tw:bg-white",
+        "tw:flex",
+    ];
+    let unprefixed = vec!["md:text-xl", "p-4", "hover:-mr-4", "bg-white", "flex"];
+
+    let sorted_prefixed = prefixed_sorter.sort_classes(&prefixed);
+    let sorted_unprefixed = normal_sorter.sort_classes(&unprefixed);
+
+    assert_eq!(
+        normalize_all(sorted_prefixed.clone(), "tw"),
+        sorted_unprefixed
+    );
+    assert!(sorted_prefixed.iter().all(|class| class.starts_with("tw:")));
+}
+
+#[test]
+fn prefixed_sort_key_uses_normalized_class() {
+    let sorter = HybridSorter::new_with_tailwind_prefix(Some("tw"));
+
+    assert!(HybridSorter::new().get_sort_key("tw-p-4").is_none());
+
+    let key = sorter
+        .get_sort_key("hover:-tw-mr-4")
+        .expect("prefixed class should sort as a known Tailwind utility");
+
+    assert_eq!(key.class.as_str(), "hover:-mr-4");
+    assert!(key.is_negative);
+}
+
+#[test]
+fn rustywind_flag_preserves_original_prefixed_classes_in_output() {
+    let app = RustyWind {
+        regex: FinderRegex::DefaultRegex,
+        sorter: Sorter::PatternSorter,
+        allow_duplicates: false,
+        class_wrapping: Default::default(),
+        tailwind_prefix: Some("tw".to_string()),
+    };
+
+    let input = r#"<div class="tw:p-4 tw:bg-white tw:md:text-xl tw:hover:-mr-4"></div>"#;
+    let sorted = app.sort_file_contents(input);
+
+    assert!(sorted.contains("tw:p-4"));
+    assert!(sorted.contains("tw:bg-white"));
+    assert!(sorted.contains("tw:md:text-xl"));
+    assert!(sorted.contains("tw:hover:-mr-4"));
+    assert!(!sorted.contains(r#"class="p-4"#));
+}
+
+#[test]
+fn custom_sorter_uses_normalized_prefixed_fallback_after_exact_lookup() {
+    let app = RustyWind {
+        regex: FinderRegex::DefaultRegex,
+        sorter: Sorter::new(
+            [("bg-white".to_string(), 0), ("p-4".to_string(), 1)]
+                .into_iter()
+                .collect(),
+        ),
+        allow_duplicates: false,
+        class_wrapping: Default::default(),
+        tailwind_prefix: Some("tw".to_string()),
+    };
+
+    assert_eq!(app.sort_classes("tw-p-4 tw-bg-white"), "tw-bg-white tw-p-4");
+    assert_eq!(app.sort_classes("tw:p-4 tw:bg-white"), "tw:bg-white tw:p-4");
+}
+
+#[test]
+fn custom_sorter_variant_fallback_keeps_v3_prefixed_exact_order() {
+    let app = RustyWind {
+        regex: FinderRegex::DefaultRegex,
+        sorter: Sorter::new(
+            [("tw-bg-white".to_string(), 0), ("tw-p-4".to_string(), 1)]
+                .into_iter()
+                .collect(),
+        ),
+        allow_duplicates: false,
+        class_wrapping: Default::default(),
+        tailwind_prefix: Some("tw".to_string()),
+    };
+
+    assert_eq!(
+        app.sort_classes("md:tw-p-4 md:tw-bg-white"),
+        "md:tw-bg-white md:tw-p-4"
+    );
+}
+
+#[test]
+fn custom_sorter_variant_fallback_keeps_v4_prefixed_exact_order() {
+    let app = RustyWind {
+        regex: FinderRegex::DefaultRegex,
+        sorter: Sorter::new(
+            [("tw:bg-white".to_string(), 0), ("tw:p-4".to_string(), 1)]
+                .into_iter()
+                .collect(),
+        ),
+        allow_duplicates: false,
+        class_wrapping: Default::default(),
+        tailwind_prefix: Some("tw".to_string()),
+    };
+
+    assert_eq!(
+        app.sort_classes("tw:md:p-4 tw:md:bg-white"),
+        "tw:md:bg-white tw:md:p-4"
+    );
+}

--- a/rustywind-core/tests/test_tailwind_prefix.rs
+++ b/rustywind-core/tests/test_tailwind_prefix.rs
@@ -60,6 +60,18 @@ fn tailwind_v4_prefixed_classes_sort_like_unprefixed_classes() {
 }
 
 #[test]
+fn mixed_prefixed_and_unprefixed_classes_sort_together() {
+    let sorter = HybridSorter::new_with_tailwind_prefix(Some("tw"));
+
+    let classes = vec!["tw-p-4", "text-xl", "tw-flex"];
+
+    assert_eq!(
+        sorter.sort_classes(&classes),
+        vec!["tw-flex", "tw-p-4", "text-xl"]
+    );
+}
+
+#[test]
 fn prefixed_sort_key_uses_normalized_class() {
     let sorter = HybridSorter::new_with_tailwind_prefix(Some("tw"));
 

--- a/rustywind-vite/Cargo.toml
+++ b/rustywind-vite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustywind_vite"
-version = "0.4.0-alpha.1"
+version = "0.4.0-rc.1"
 description = "Additional functionality for rustywind_core specific to Vite"
 documentation = "https://docs.rs/rustywind_vite"
 authors.workspace = true
@@ -10,7 +10,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-rustywind_core = { path = "../rustywind-core", version = "=0.4.0-alpha.1" }
+rustywind_core = { path = "../rustywind-core", version = "=0.4.0-rc.1" }
 
 # tls
 rustls = { version = "0.23", features = ["ring"], default-features = false }


### PR DESCRIPTION
## Summary

Add explicit Tailwind prefix support for sorting class lists.

- add a `--tailwind-prefix` CLI option
- normalize Tailwind v3 and v4 prefixed classes before sort-key generation
- preserve original prefixed class strings in output
- reuse prefix-aware sorter caches and support custom-sorter fallback paths
- add regression coverage for v3, v4, negative, variant, and custom sorter cases

Closes: #135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--tailwind-prefix` CLI option for specifying Tailwind prefix variants.

* **Breaking Changes**
  * `RustyWind` now requires explicit `tailwind_prefix` field in struct literals.
  * `PatternSorter` is no longer a unit struct; use `new()` or `default()` constructors.
  * Prefix-aware sorting now stores normalized class instead of original input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->