### PR TITLE
Preserve custom regex capture whitespace

### DIFF
--- a/rustywind-core/src/app.rs
+++ b/rustywind-core/src/app.rs
@@ -83,9 +83,40 @@ impl RustyWind {
                 .or_else(|| caps.get(2))
                 .expect("class extractor regex must include a capture group")
                 .as_str();
-            let sorted_classes = self.sort_classes(classes);
+            let sorted_classes = self.sort_capture_classes(classes);
             caps[0].replace(classes, &sorted_classes)
         })
+    }
+
+    fn sort_capture_classes(&self, class_string: &str) -> String {
+        if matches!(self.regex, FinderRegex::CustomRegex(_)) {
+            return self.sort_classes_preserving_outer_whitespace(class_string);
+        }
+
+        self.sort_classes(class_string)
+    }
+
+    fn sort_classes_preserving_outer_whitespace(&self, class_string: &str) -> String {
+        let Some((start, _)) = class_string
+            .char_indices()
+            .find(|(_, character)| !character.is_ascii_whitespace())
+        else {
+            return class_string.to_string();
+        };
+
+        let end = class_string
+            .char_indices()
+            .rev()
+            .find(|(_, character)| !character.is_ascii_whitespace())
+            .map(|(index, character)| index + character.len_utf8())
+            .unwrap_or(start);
+
+        format!(
+            "{}{}{}",
+            &class_string[..start],
+            self.sort_classes(&class_string[start..end]),
+            &class_string[end..]
+        )
     }
 
     /// Given a [&str] of whitespace-separated classes, returns a [String] of sorted classes.
@@ -620,6 +651,19 @@ mod tests {
 
         // pattern-based sorting: margin(25) < display(35) < padding(252)
         assert_eq!(output, r#"<div class="m-4 flex p-4"></div>"#);
+    }
+
+    #[test]
+    fn test_custom_regex_preserves_ruby_interpolation_spacing() {
+        let app = RustyWind {
+            regex: FinderRegex::CustomRegex(
+                Regex::new(r#"class(?:=|:\s*)(?:'|")([^"']+?)(?:'|")"#).unwrap(),
+            ),
+            ..RUSTYWIND_DEFAULT
+        };
+        let input = r#"class: "box f-col #{reply.reply_id ? "ok" : ""}""#;
+
+        assert_eq!(app.sort_file_contents(input), input);
     }
 
     /// Test that arbitrary variant classes are matched by the regex (Issue #115)


### PR DESCRIPTION
Fixes #124.

## Summary
- Preserve leading and trailing whitespace from custom-regex captures before/after sorting the captured class tokens.
- Keep the default HTML class behavior unchanged, including multiline class flattening.
- Add a regression for the reported Ruby/Crystal interpolation case so `? "ok"` is not rewritten to `?"ok"`.

## Validation
- `cargo test -p rustywind_core test_custom_regex_preserves_ruby_interpolation_spacing`
- Manual CLI repro with the issue command now preserves the Ruby ternary spacing.
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom regex patterns now properly preserve leading and trailing whitespace in captured class strings while continuing to correctly sort class values. This improvement is especially beneficial for users working with Ruby interpolation and other dynamic templating syntax where spacing must be carefully maintained.

* **Tests**
  * Added test case to verify correct whitespace preservation when using custom regex patterns containing Ruby interpolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->