### PR TITLE
Skip class strings containing template syntax (fixes 0.25.0 regression)

### DIFF
--- a/rustywind-core/src/app.rs
+++ b/rustywind-core/src/app.rs
@@ -83,6 +83,11 @@ impl RustyWind {
                 .or_else(|| caps.get(2))
                 .expect("class extractor regex must include a capture group")
                 .as_str();
+
+            if contains_template_syntax(classes) {
+                return caps[0].to_string();
+            }
+
             let sorted_classes = self.sort_classes(classes);
             caps[0].replace(classes, &sorted_classes)
         })
@@ -280,6 +285,18 @@ fn prefixed_pattern_sorter(tailwind_prefix: &str) -> Arc<HybridSorter> {
                 )))
             }),
     )
+}
+
+/// Opening delimiters of template-language tags (ERB/EJS `<% %>`, PHP `<? ?>`,
+/// Handlebars/Jinja/Liquid `{{ }}` and `{% %}`, Ruby string interpolation `#{ }`).
+/// Class strings containing embedded code can't be safely split on whitespace —
+/// sorting them would move tokens across code boundaries and corrupt the template.
+const TEMPLATE_DELIMITERS: [&str; 5] = ["<%", "<?", "{{", "{%", "#{"];
+
+fn contains_template_syntax(class_string: &str) -> bool {
+    TEMPLATE_DELIMITERS
+        .iter()
+        .any(|delimiter| class_string.contains(delimiter))
 }
 
 fn split_class_tokens(class_string: &str) -> Vec<&str> {
@@ -520,6 +537,36 @@ mod tests {
         r#"<div><p><img height="100" width="250" /></p><p></p></div>"#,
         r#"<div><p><img height="100" width="250" /></p><p></p></div>"#
         ; "makes no change to elements without class string"
+    )]
+    #[test_case(
+        &RUSTYWIND_DEFAULT,
+        r#"<div class="<%= layout == :cards ? 'flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center' : 'sm:flex sm:items-center' %>">"#,
+        r#"<div class="<%= layout == :cards ? 'flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center' : 'sm:flex sm:items-center' %>">"#
+        ; "makes no change to class string that is a single erb ternary"
+    )]
+    #[test_case(
+        &RUSTYWIND_DEFAULT,
+        r#"<span class="inline-flex items-center <%= data["company"].present? ? 'h-auto py-2 px-3 gap-x-1.5' : 'h-8 py-1 px-2 gap-x-0.5' %> rounded-md">"#,
+        r#"<span class="inline-flex items-center <%= data["company"].present? ? 'h-auto py-2 px-3 gap-x-1.5' : 'h-8 py-1 px-2 gap-x-0.5' %> rounded-md">"#
+        ; "makes no change to class string with erb tag between static classes"
+    )]
+    #[test_case(
+        &RUSTYWIND_DEFAULT,
+        r#"<span class="flex h-8 w-8 items-center justify-center rounded-full <%= record.active? ? 'bg-brand-yellow text-gray-950' : 'border-2 border-gray-300 bg-white' %>">"#,
+        r#"<span class="flex h-8 w-8 items-center justify-center rounded-full <%= record.active? ? 'bg-brand-yellow text-gray-950' : 'border-2 border-gray-300 bg-white' %>">"#
+        ; "makes no change to class string with static classes before an erb ternary"
+    )]
+    #[test_case(
+        &RUSTYWIND_DEFAULT,
+        r##"<div class="box f-col #{reply.reply_id ? "ok" : ""}">"##,
+        r##"<div class="box f-col #{reply.reply_id ? "ok" : ""}">"##
+        ; "makes no change to class string with ruby string interpolation"
+    )]
+    #[test_case(
+        &RUSTYWIND_DEFAULT,
+        r#"<div class="p-4 {{ active ? 'flex flex-col' : 'hidden' }}">"#,
+        r#"<div class="p-4 {{ active ? 'flex flex-col' : 'hidden' }}">"#
+        ; "makes no change to class string with mustache style interpolation"
     )]
     fn test_sort_file_contents(app: &RustyWind, input: &str, output: &str) {
         assert_eq!(app.sort_file_contents(input), output);

--- a/rustywind-core/src/app.rs
+++ b/rustywind-core/src/app.rs
@@ -292,18 +292,47 @@ fn prefixed_pattern_sorter(tailwind_prefix: &str) -> Arc<HybridSorter> {
     )
 }
 
-/// Opening delimiters of template-language tags (ERB/EJS `<% %>`, PHP `<? ?>`,
-/// Handlebars/Jinja/Liquid `{{ }}` and `{% %}`, Ruby string interpolation `#{ }`).
-/// Class strings containing embedded code can't be safely split on whitespace —
-/// sorting them would move tokens across code boundaries and corrupt the template.
+/// Delimiters of template-language tags (ERB/EJS `<% %>`, PHP `<? ?>`,
+/// Handlebars/Jinja/Liquid `{{ }}` and `{% %}`, Ruby string interpolation `#{ }`,
+/// JS template literals `${ }`). Class strings containing embedded code can't be
+/// safely split on whitespace — sorting them would move tokens across code
+/// boundaries and corrupt the template. Closing delimiters are included because
+/// a quote inside the template code can split the regex match, leaving a
+/// fragment that contains only the tail of a tag.
 // TODO: instead of skipping the whole class string, tokenize template tags as
 // opaque units so the static classes around them can still be sorted.
-const TEMPLATE_DELIMITERS: [&str; 5] = ["<%", "<?", "{{", "{%", "#{"];
+const TEMPLATE_DELIMITERS: [&str; 10] =
+    ["<%", "%>", "<?", "?>", "{{", "}}", "{%", "%}", "#{", "${"];
 
 fn contains_template_syntax(class_string: &str) -> bool {
     TEMPLATE_DELIMITERS
         .iter()
         .any(|delimiter| class_string.contains(delimiter))
+}
+
+#[cfg(test)]
+mod template_syntax_tests {
+    use super::contains_template_syntax;
+
+    #[test]
+    fn detects_closing_delimiter_fragments() {
+        // a quote inside template code can split the regex match, leaving a
+        // fragment with only the tail of a tag
+        assert!(contains_template_syntax("a' %> flex p-4"));
+        assert!(contains_template_syntax("arg'}} p-4"));
+        assert!(contains_template_syntax("x %} m-4"));
+        assert!(contains_template_syntax("y ?> m-4"));
+    }
+
+    #[test]
+    fn ignores_plain_class_strings() {
+        assert!(!contains_template_syntax(
+            "flex p-4 max-w-[min(100%, 500px)]"
+        ));
+        assert!(!contains_template_syntax(
+            "[&>*]:p-4 [@supports(display:grid)]:grid"
+        ));
+    }
 }
 
 fn split_class_tokens(class_string: &str) -> Vec<&str> {
@@ -574,6 +603,12 @@ mod tests {
         r#"<div class="p-4 {{ active ? 'flex flex-col' : 'hidden' }}">"#,
         r#"<div class="p-4 {{ active ? 'flex flex-col' : 'hidden' }}">"#
         ; "makes no change to class string with mustache style interpolation"
+    )]
+    #[test_case(
+        &RUSTYWIND_DEFAULT,
+        r#"html`<div class="p-4 m-4 ${active ? 'flex flex-col' : 'hidden'}">`"#,
+        r#"html`<div class="p-4 m-4 ${active ? 'flex flex-col' : 'hidden'}">`"#
+        ; "makes no change to class string with js template literal interpolation"
     )]
     fn test_sort_file_contents(app: &RustyWind, input: &str, output: &str) {
         assert_eq!(app.sort_file_contents(input), output);

--- a/rustywind-core/src/app.rs
+++ b/rustywind-core/src/app.rs
@@ -95,6 +95,11 @@ impl RustyWind {
 
     /// Given a [&str] of whitespace-separated classes, returns a [String] of sorted classes.
     /// Does not preserve whitespace.
+    ///
+    /// Expects plain class names only: the template-syntax guard lives in
+    /// [`Self::sort_file_contents`], so passing a string containing embedded
+    /// template code (e.g. `<%= ... %>`) will split it on whitespace like any
+    /// other classes.
     pub fn sort_classes(&self, class_string: &str) -> String {
         let extracted_classes = self.unwrap_wrapped_classes(class_string);
 
@@ -291,6 +296,8 @@ fn prefixed_pattern_sorter(tailwind_prefix: &str) -> Arc<HybridSorter> {
 /// Handlebars/Jinja/Liquid `{{ }}` and `{% %}`, Ruby string interpolation `#{ }`).
 /// Class strings containing embedded code can't be safely split on whitespace —
 /// sorting them would move tokens across code boundaries and corrupt the template.
+// TODO: instead of skipping the whole class string, tokenize template tags as
+// opaque units so the static classes around them can still be sorted.
 const TEMPLATE_DELIMITERS: [&str; 5] = ["<%", "<?", "{{", "{%", "#{"];
 
 fn contains_template_syntax(class_string: &str) -> bool {


### PR DESCRIPTION
I filed #140 after noticing my CI fail in a Ruby on Rails project. Here's my attempt at a fix (I worked with Claude Code, for full transparency). 

Fixes #140. Also fixes the corruption reported in #124.

## Fix

In `sort_file_contents`, leave a matched class string untouched when it contains a template opening delimiter: `<%` (ERB/EJS), `<?` (PHP), `{{` / `{%` (Handlebars/Jinja/Liquid), `#{` (Ruby string interpolation).

This matches the 0.24.x effect of leaving these attributes untouched — 0.24.x's restrictive regex simply didn't match them; this guard produces the same result via a skip after matching — while keeping fc7d701's improvement: arbitrary values with whitespace like `max-w-[min(100%, 500px)]` still sort correctly. 

Because the guard is in the shared `sort_file_contents` path, it also applies to `--custom-regex`, which fixes the `#{ ... ? ... : ... }` reformatting reported in #124.

## Trade-offs

- **Silent skip.** rustywind now silently skips sorting the entire class attribute when any of these delimiters appear — including the static classes around the template tag. That matches 0.24.x (which skipped the same attributes, also silently), but it is not ideal long-term: real template-aware tokenization could sort the static portions while treating each tag as an opaque unit. I left that as future work (noted in a TODO above `TEMPLATE_DELIMITERS`) to keep this PR a targeted regression fix.
- **False positives.** A class string containing a delimiter outside template code — e.g. an arbitrary value like `content-['<?']` — is now skipped too.
- **Public API.** The guard lives in `sort_file_contents`; calling `sort_classes` directly with a template-bearing string still splits it on whitespace. Its doc comment now states that it expects plain class names.

## Testing

Added five `test_case`s to `rustywind-core/src/app.rs` covering the three repros from #140, the interpolation case from #124, and a mustache-style case. 

All fail on `main` with exactly the corruption from the issue and pass with this change. 

Each asserts `sort_file_contents` is byte-identical on its input, which is what makes `--check-formatted` pass again — closing the "CI accepts the corrupted output" symptom from #140.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved class sorting to detect template syntax within `class`/`className` strings and leave those segments unchanged instead of reordering tokens.
  * Preserves common template/interpolation forms (e.g., ERB/EJS-like tags, Liquid/Jinja-like blocks, mustache-style expressions, Ruby interpolation, and JavaScript template literals).
* **Documentation**
  * Clarified expectations for how template code should be treated during class sorting.
* **Tests**
  * Added coverage for template delimiter detection and ensured sorting remains stable for template-containing class strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->