### PR TITLE
Add deterministic Tailwind parity checks

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,6 +6,9 @@ fmt:
 clippy:
     cargo clippy -- -D warnings
 
+compare-tailwind *args:
+    cargo xtask compare run {{args}}
+
 update:
     cargo update --workspace
 

--- a/tests/tailwind-compare/README.md
+++ b/tests/tailwind-compare/README.md
@@ -1,0 +1,49 @@
+# Tailwind comparison engine
+
+This package compares RustyWind's ordering of static quoted class attributes
+with Prettier's Tailwind CSS plugin across a pinned external corpus. It supports
+TSX, Svelte, and Astro sources. The engine reverses eligible class lists in
+memory before invoking either formatter, so already-sorted source does not
+produce false agreement.
+
+Install the exact toolchain and run the focused unit tests with:
+
+```bash
+cd tests/tailwind-compare
+npm ci
+npm test
+```
+
+The repository's `xtask` command is the intended orchestration layer. It checks
+out the corpus and supplies every input explicitly:
+
+```bash
+node compare.mjs \
+  --corpus example/project \
+  --repo /path/to/project \
+  --revision 0123456789abcdef0123456789abcdef01234567 \
+  --scope src \
+  --kind tsx \
+  --limit 30 \
+  --rustywind ../../target/release/rustywind \
+  --stylesheet tailwind.css \
+  --output /path/to/report.json
+```
+
+Candidates are ranked by descending static attribute count, then by bytewise
+UTF-8 relative path. The report fingerprint is SHA-256 over those ordered
+selected records: relative path, NUL, scrambled source, NUL. Reports contain
+only logical corpus paths, not checkout or executable paths.
+
+The process exits nonzero for invalid arguments, missing inputs, and a failed
+Tailwind classification probe. Source parse errors and RustyWind failures are
+recorded in the report for the caller to interpret alongside ordering and
+extraction findings.
+
+Only quoted `class` and `className` literals without template delimiters are in
+scope. Dynamic expressions, `class:list`, helper calls such as `cn` and `cva`,
+and project-specific Tailwind configuration are outside this comparison. A
+token is Tailwind-known when the pinned Prettier plugin moves it past two
+unknown sentinels using the supplied minimal Tailwind 4 stylesheet. Differences
+that preserve the order of known tokens are reported separately as
+`custom-only`.

--- a/tests/tailwind-compare/compare.mjs
+++ b/tests/tailwind-compare/compare.mjs
@@ -16,6 +16,7 @@ import * as prettier from "prettier";
 import * as astroPlugin from "prettier-plugin-astro";
 import * as sveltePlugin from "prettier-plugin-svelte";
 import * as tailwindPlugin from "prettier-plugin-tailwindcss";
+import { createSorter } from "prettier-plugin-tailwindcss/sorter";
 
 import {
   classifyDifference,
@@ -31,6 +32,7 @@ import {
 } from "./lib.mjs";
 
 const engineDirectory = dirname(fileURLToPath(import.meta.url));
+const rustywindTimeout = 30_000;
 const ignoredDirectories = new Set([
   ".git",
   ".svelte-kit",
@@ -169,6 +171,8 @@ function resolveConfiguration(arguments_) {
 function validateRustywind(configuration) {
   const result = spawnSync(configuration.rustywind, ["--version"], {
     encoding: "utf8",
+    killSignal: "SIGKILL",
+    timeout: rustywindTimeout,
   });
   if (result.error) {
     throw new Error(
@@ -249,7 +253,9 @@ function runRustywind(configuration, candidate) {
     {
       encoding: "utf8",
       input: candidate.scrambledSource,
+      killSignal: "SIGKILL",
       maxBuffer: 20 * 1024 * 1024,
+      timeout: rustywindTimeout,
     },
   );
   if (result.error) {
@@ -268,36 +274,39 @@ function unique(tokens) {
   return [...new Set(tokens)];
 }
 
-async function probeKnownClasses(tokens, stylesheet) {
-  const known = new Map(tokens.map((token) => [token, false]));
-  const eligible = unique(tokens).filter(
-    (token) =>
-      !token.includes("\n") && !(token.includes('"') && token.includes("'")),
-  );
-  if (eligible.length === 0) return known;
+export async function probeKnownClasses(tokens, stylesheet) {
+  const probes = unique(tokens).map((token, index) => {
+    let suffix = 0;
+    let left;
+    let right;
+    do {
+      // NUL makes markers invalid Tailwind candidates under any stylesheet
+      left = `\0__rustywind_unknown_${index}_${suffix}_a`;
+      right = `\0__rustywind_unknown_${index}_${suffix}_b`;
+      suffix += 1;
+    } while (token === left || token === right);
+    return { left, right, token };
+  });
+  if (probes.length === 0) return new Map();
 
-  const fixtures = eligible.map((token) => {
-    const quote = token.includes('"') ? "'" : '"';
-    return `<div class=${quote}__rustywind_unknown_a ${token} __rustywind_unknown_b${quote}></div>`;
+  const sorter = await createSorter({
+    preserveDuplicates: true,
+    stylesheetPath: stylesheet,
   });
-  const formatted = await prettier.format(fixtures.join("\n"), {
-    parser: "html",
-    plugins: [tailwindPlugin],
-    tailwindStylesheet: stylesheet,
-  });
-  const formattedAttributes =
-    extractAttributes(formatted).map(splitClassTokens);
-  for (const [index, token] of eligible.entries()) {
-    known.set(
-      token,
-      same(formattedAttributes[index] ?? [], [
-        "__rustywind_unknown_a",
-        "__rustywind_unknown_b",
-        token,
-      ]),
-    );
-  }
-  return known;
+  const results = sorter.sortClassLists(
+    probes.map(({ left, right, token }) => [left, token, right]),
+  );
+
+  return new Map(
+    probes.map(({ left, right, token }, index) => {
+      const result = results[index] ?? [];
+      if (same(result, [left, right, token])) return [token, true];
+      if (same(result, [left, token, right])) return [token, false];
+      throw new Error(
+        `Tailwind sorter returned an unexpected probe result for ${JSON.stringify(token)}`,
+      );
+    }),
+  );
 }
 
 async function validatePrettier(configuration) {
@@ -475,10 +484,7 @@ async function compareCandidates(configuration, candidates) {
   return { details: pending, failures, summary };
 }
 
-async function main() {
-  const configuration = resolveConfiguration(
-    parseArguments(process.argv.slice(2)),
-  );
+async function runComparison(configuration) {
   validateRustywind(configuration);
   await validatePrettier(configuration);
   const candidates = selectCandidates(configuration);
@@ -520,7 +526,23 @@ async function main() {
   process.stdout.write(`${JSON.stringify(result.summary)}\n`);
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error.message || error}\n`);
-  process.exitCode = 1;
-});
+async function main() {
+  const configuration = resolveConfiguration(
+    parseArguments(process.argv.slice(2)),
+  );
+  try {
+    await runComparison(configuration);
+  } catch (error) {
+    throw new Error(scrubError(error, configuration), { cause: error });
+  }
+}
+
+if (
+  process.argv[1] !== undefined &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message || error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/tailwind-compare/compare.mjs
+++ b/tests/tailwind-compare/compare.mjs
@@ -1,0 +1,526 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import * as prettier from "prettier";
+import * as astroPlugin from "prettier-plugin-astro";
+import * as sveltePlugin from "prettier-plugin-svelte";
+import * as tailwindPlugin from "prettier-plugin-tailwindcss";
+
+import {
+  classifyDifference,
+  compareUtf8,
+  corpusFingerprint,
+  extractAttributes,
+  kinds,
+  orderCandidates,
+  same,
+  sameMultiset,
+  scrambleAttributes,
+  splitClassTokens,
+} from "./lib.mjs";
+
+const engineDirectory = dirname(fileURLToPath(import.meta.url));
+const ignoredDirectories = new Set([
+  ".git",
+  ".svelte-kit",
+  "build",
+  "dist",
+  "node_modules",
+]);
+const syntaxPlugins = {
+  astro: [astroPlugin],
+  svelte: [sveltePlugin],
+  tsx: [],
+};
+
+function usage() {
+  return [
+    "usage: node compare.mjs",
+    "  --corpus NAME --repo PATH --revision REVISION --scope PATH",
+    "  --kind tsx|svelte|astro --limit COUNT --rustywind PATH",
+    "  --stylesheet PATH --output PATH",
+  ].join("\n");
+}
+
+function parseArguments(argv) {
+  if (argv.includes("--help")) {
+    process.stdout.write(`${usage()}\n`);
+    process.exit(0);
+  }
+
+  const options = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (
+      !name?.startsWith("--") ||
+      value === undefined ||
+      value.startsWith("--")
+    ) {
+      throw new Error(usage());
+    }
+    if (options.has(name)) throw new Error(`duplicate argument: ${name}`);
+    options.set(name, value);
+  }
+
+  const knownArguments = new Set([
+    "--corpus",
+    "--kind",
+    "--limit",
+    "--output",
+    "--repo",
+    "--revision",
+    "--rustywind",
+    "--scope",
+    "--stylesheet",
+  ]);
+  for (const name of options.keys()) {
+    if (!knownArguments.has(name)) throw new Error(`unknown argument: ${name}`);
+  }
+  for (const name of knownArguments) {
+    if (!options.has(name))
+      throw new Error(`missing argument: ${name}\n${usage()}`);
+  }
+
+  const limitText = options.get("--limit");
+  if (!/^\d+$/u.test(limitText))
+    throw new Error("--limit must be a positive integer");
+  const limit = Number.parseInt(limitText, 10);
+  if (!Number.isSafeInteger(limit) || limit < 1) {
+    throw new Error("--limit must be a positive integer");
+  }
+
+  const kind = options.get("--kind");
+  if (!Object.hasOwn(kinds, kind)) {
+    throw new Error("--kind must be one of: tsx, svelte, astro");
+  }
+
+  const corpus = options.get("--corpus");
+  const revision = options.get("--revision");
+  if (corpus.length === 0) throw new Error("--corpus must not be empty");
+  if (revision.length === 0) throw new Error("--revision must not be empty");
+
+  return {
+    corpus,
+    kind,
+    limit,
+    output: resolve(options.get("--output")),
+    repo: resolve(options.get("--repo")),
+    revision,
+    rustywind: resolve(options.get("--rustywind")),
+    scopeArgument: options.get("--scope"),
+    stylesheet: resolve(options.get("--stylesheet")),
+  };
+}
+
+function ensureFile(path, argument) {
+  if (!existsSync(path) || !statSync(path).isFile()) {
+    throw new Error(`${argument} must name an existing file`);
+  }
+}
+
+function ensureDirectory(path, argument) {
+  if (!existsSync(path) || !statSync(path).isDirectory()) {
+    throw new Error(`${argument} must name an existing directory`);
+  }
+}
+
+function within(parent, child) {
+  const path = relative(parent, child);
+  return (
+    path === "" ||
+    (!path.startsWith(`..${sep}`) && path !== ".." && !isAbsolute(path))
+  );
+}
+
+function normalizeRelativePath(path) {
+  return path.split(sep).join("/");
+}
+
+function resolveConfiguration(arguments_) {
+  ensureDirectory(arguments_.repo, "--repo");
+  ensureFile(arguments_.rustywind, "--rustywind");
+  ensureFile(arguments_.stylesheet, "--stylesheet");
+
+  const scope = resolve(arguments_.repo, arguments_.scopeArgument);
+  if (!within(arguments_.repo, scope))
+    throw new Error("--scope must be inside --repo");
+  ensureDirectory(scope, "--scope");
+
+  return {
+    ...arguments_,
+    scope,
+    logicalScope:
+      normalizeRelativePath(relative(arguments_.repo, scope)) || ".",
+  };
+}
+
+function validateRustywind(configuration) {
+  const result = spawnSync(configuration.rustywind, ["--version"], {
+    encoding: "utf8",
+  });
+  if (result.error) {
+    throw new Error(
+      `could not invoke --rustywind: ${scrubError(result.error, configuration)}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `--rustywind --version exited with status ${result.status}: ${scrubError(
+        result.stderr,
+        configuration,
+      )}`,
+    );
+  }
+}
+
+function walk(directory, extension) {
+  const files = [];
+  const entries = readdirSync(directory, { withFileTypes: true }).sort(
+    (left, right) => compareUtf8(left.name, right.name),
+  );
+  for (const entry of entries) {
+    if (entry.isDirectory() && ignoredDirectories.has(entry.name)) continue;
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(path, extension));
+    } else if (entry.isFile() && path.endsWith(extension)) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function selectCandidates(configuration) {
+  const candidates = walk(
+    configuration.scope,
+    kinds[configuration.kind].extension,
+  ).map((file) => {
+    const source = readFileSync(file, "utf8");
+    const path = normalizeRelativePath(relative(configuration.repo, file));
+    return {
+      attributes: extractAttributes(source).length,
+      file,
+      path,
+      scrambledSource: scrambleAttributes(source),
+    };
+  });
+  return orderCandidates(candidates, configuration.limit);
+}
+
+function prettierOptions(configuration, file) {
+  return {
+    filepath: file,
+    parser: kinds[configuration.kind].parser,
+    plugins: [...syntaxPlugins[configuration.kind], tailwindPlugin],
+    tailwindStylesheet: configuration.stylesheet,
+  };
+}
+
+function scrubError(error, configuration) {
+  let message = String(error?.stderr || error?.message || error).trim();
+  const paths = [
+    [configuration.repo, "<repo>"],
+    [configuration.rustywind, "<rustywind>"],
+    [configuration.stylesheet, "<stylesheet>"],
+    [engineDirectory, "<engine>"],
+  ].sort((left, right) => right[0].length - left[0].length);
+  for (const [path, replacement] of paths) {
+    message = message.split(path).join(replacement);
+  }
+  return message || "unknown error";
+}
+
+function runRustywind(configuration, candidate) {
+  const result = spawnSync(
+    configuration.rustywind,
+    ["--stdin", "--stdin-filename", candidate.file, "--quiet"],
+    {
+      encoding: "utf8",
+      input: candidate.scrambledSource,
+      maxBuffer: 20 * 1024 * 1024,
+    },
+  );
+  if (result.error) {
+    result.error.invocation = true;
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const error = new Error(`RustyWind exited with status ${result.status}`);
+    error.stderr = result.stderr;
+    throw error;
+  }
+  return result.stdout;
+}
+
+function unique(tokens) {
+  return [...new Set(tokens)];
+}
+
+async function probeKnownClasses(tokens, stylesheet) {
+  const known = new Map(tokens.map((token) => [token, false]));
+  const eligible = unique(tokens).filter(
+    (token) =>
+      !token.includes("\n") && !(token.includes('"') && token.includes("'")),
+  );
+  if (eligible.length === 0) return known;
+
+  const fixtures = eligible.map((token) => {
+    const quote = token.includes('"') ? "'" : '"';
+    return `<div class=${quote}__rustywind_unknown_a ${token} __rustywind_unknown_b${quote}></div>`;
+  });
+  const formatted = await prettier.format(fixtures.join("\n"), {
+    parser: "html",
+    plugins: [tailwindPlugin],
+    tailwindStylesheet: stylesheet,
+  });
+  const formattedAttributes =
+    extractAttributes(formatted).map(splitClassTokens);
+  for (const [index, token] of eligible.entries()) {
+    known.set(
+      token,
+      same(formattedAttributes[index] ?? [], [
+        "__rustywind_unknown_a",
+        "__rustywind_unknown_b",
+        token,
+      ]),
+    );
+  }
+  return known;
+}
+
+async function validatePrettier(configuration) {
+  const fixtures = {
+    astro: '---\n---\n<div class="p-4 flex"></div>\n',
+    svelte: '<div class="p-4 flex"></div>\n',
+    tsx: '<div className="p-4 flex" />;\n',
+  };
+  try {
+    await prettier.format(
+      fixtures[configuration.kind],
+      prettierOptions(
+        configuration,
+        join(configuration.scope, `__rustywind_probe.${configuration.kind}`),
+      ),
+    );
+    const known = await probeKnownClasses(["flex"], configuration.stylesheet);
+    if (known.get("flex") !== true) {
+      throw new Error("Tailwind did not recognize the built-in flex utility");
+    }
+  } catch (error) {
+    throw new Error(
+      `Prettier configuration probe failed: ${scrubError(error, configuration)}`,
+    );
+  }
+}
+
+function packageVersion(name) {
+  return JSON.parse(
+    readFileSync(join(engineDirectory, "node_modules", name, "package.json")),
+  ).version;
+}
+
+function compareAttribute(
+  summary,
+  pending,
+  candidate,
+  attribute,
+  original,
+  prettierTokens,
+  rustywindTokens,
+) {
+  summary.prettierChanged += Number(!same(original, prettierTokens));
+  summary.rustywindChanged += Number(!same(original, rustywindTokens));
+
+  if (!sameMultiset(prettierTokens, rustywindTokens)) {
+    summary.extractionMismatch += 1;
+    pending.push({
+      attribute,
+      kind: "token-multiset",
+      original,
+      path: candidate.path,
+      prettier: prettierTokens,
+      rustywind: rustywindTokens,
+    });
+    return;
+  }
+  if (same(prettierTokens, rustywindTokens)) {
+    summary.exact += 1;
+    return;
+  }
+  pending.push({
+    attribute,
+    original,
+    path: candidate.path,
+    prettier: prettierTokens,
+    rustywind: rustywindTokens,
+  });
+}
+
+async function compareCandidates(configuration, candidates) {
+  const summary = {
+    prettierChanged: 0,
+    rustywindChanged: 0,
+    exact: 0,
+    customOnly: 0,
+    knownOrderMismatch: 0,
+    extractionMismatch: 0,
+    failures: 0,
+  };
+  const pending = [];
+  const failures = [];
+
+  for (const candidate of candidates) {
+    let prettierOutput;
+    let rustywindOutput;
+    try {
+      prettierOutput = await prettier.format(
+        candidate.scrambledSource,
+        prettierOptions(configuration, candidate.file),
+      );
+    } catch (error) {
+      failures.push({
+        path: candidate.path,
+        stage: "prettier",
+        error: scrubError(error, configuration),
+      });
+      continue;
+    }
+    try {
+      rustywindOutput = runRustywind(configuration, candidate);
+    } catch (error) {
+      if (error.invocation) throw error;
+      failures.push({
+        path: candidate.path,
+        stage: "rustywind",
+        error: scrubError(error, configuration),
+      });
+      continue;
+    }
+
+    const originalAttributes = extractAttributes(candidate.scrambledSource);
+    const prettierAttributes = extractAttributes(prettierOutput);
+    const rustywindAttributes = extractAttributes(rustywindOutput);
+    if (
+      originalAttributes.length !== candidate.attributes ||
+      prettierAttributes.length !== candidate.attributes ||
+      rustywindAttributes.length !== candidate.attributes
+    ) {
+      summary.extractionMismatch += candidate.attributes;
+      pending.push({
+        kind: "attribute-count",
+        expected: candidate.attributes,
+        original: originalAttributes.length,
+        path: candidate.path,
+        prettier: prettierAttributes.length,
+        rustywind: rustywindAttributes.length,
+      });
+      continue;
+    }
+
+    for (let index = 0; index < candidate.attributes; index += 1) {
+      compareAttribute(
+        summary,
+        pending,
+        candidate,
+        index,
+        splitClassTokens(originalAttributes[index]),
+        splitClassTokens(prettierAttributes[index]),
+        splitClassTokens(rustywindAttributes[index]),
+      );
+    }
+  }
+
+  const orderDifferences = pending.filter(
+    (detail) => detail.kind === undefined,
+  );
+  let known;
+  try {
+    known = await probeKnownClasses(
+      orderDifferences.flatMap(
+        ({ prettier: prettierTokens, rustywind: rustywindTokens }) => [
+          ...prettierTokens,
+          ...rustywindTokens,
+        ],
+      ),
+      configuration.stylesheet,
+    );
+  } catch (error) {
+    throw new Error(
+      `Tailwind classification probe failed: ${scrubError(error, configuration)}`,
+    );
+  }
+
+  for (const detail of orderDifferences) {
+    detail.kind = classifyDifference(detail.prettier, detail.rustywind, known);
+    detail.prettierUnknown = unique(
+      detail.rustywind.filter((token) => known.get(token) !== true),
+    );
+    if (detail.kind === "custom-only") summary.customOnly += 1;
+    if (detail.kind === "known-order") summary.knownOrderMismatch += 1;
+  }
+
+  summary.failures = failures.length;
+  return { details: pending, failures, summary };
+}
+
+async function main() {
+  const configuration = resolveConfiguration(
+    parseArguments(process.argv.slice(2)),
+  );
+  validateRustywind(configuration);
+  await validatePrettier(configuration);
+  const candidates = selectCandidates(configuration);
+  const comparison = await compareCandidates(configuration, candidates);
+  const attributes = candidates.reduce(
+    (total, candidate) => total + candidate.attributes,
+    0,
+  );
+  const result = {
+    schemaVersion: 1,
+    corpus: {
+      name: configuration.corpus,
+      revision: configuration.revision,
+      scope: configuration.logicalScope,
+      kind: configuration.kind,
+      limit: configuration.limit,
+      files: candidates.length,
+      attributes,
+      fingerprint: corpusFingerprint(candidates),
+    },
+    versions: {
+      prettier: prettier.version,
+      prettierPluginTailwindcss: packageVersion("prettier-plugin-tailwindcss"),
+      tailwindcss: packageVersion("tailwindcss"),
+      prettierPluginAstro: packageVersion("prettier-plugin-astro"),
+      prettierPluginSvelte: packageVersion("prettier-plugin-svelte"),
+    },
+    summary: comparison.summary,
+    candidates: candidates.map(({ path, attributes: count }) => ({
+      path,
+      attributes: count,
+    })),
+    details: comparison.details,
+    failures: comparison.failures,
+  };
+
+  mkdirSync(dirname(configuration.output), { recursive: true });
+  writeFileSync(configuration.output, `${JSON.stringify(result, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(result.summary)}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message || error}\n`);
+  process.exitCode = 1;
+});

--- a/tests/tailwind-compare/lib.mjs
+++ b/tests/tailwind-compare/lib.mjs
@@ -104,12 +104,17 @@ export function classifyDifference(prettierTokens, rustywindTokens, known) {
   if (!sameMultiset(prettierTokens, rustywindTokens)) return "token-multiset";
   if (same(prettierTokens, rustywindTokens)) return "exact";
 
-  const prettierKnown = prettierTokens.filter(
-    (token) => known.get(token) === true,
-  );
-  const rustywindKnown = rustywindTokens.filter(
-    (token) => known.get(token) === true,
-  );
+  const isKnown = (token) => {
+    const value = known.get(token);
+    if (typeof value !== "boolean") {
+      throw new Error(
+        `missing Tailwind classification for token: ${JSON.stringify(token)}`,
+      );
+    }
+    return value;
+  };
+  const prettierKnown = prettierTokens.filter(isKnown);
+  const rustywindKnown = rustywindTokens.filter(isKnown);
   return same(prettierKnown, rustywindKnown) ? "custom-only" : "known-order";
 }
 

--- a/tests/tailwind-compare/lib.mjs
+++ b/tests/tailwind-compare/lib.mjs
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+
+const attributePattern = /(^|[\s<])(class(?:Name)?\s*=\s*)(["'])([\s\S]*?)\3/gm;
+
+export const kinds = Object.freeze({
+  astro: { extension: ".astro", parser: "astro" },
+  svelte: { extension: ".svelte", parser: "svelte" },
+  tsx: { extension: ".tsx", parser: "typescript" },
+});
+
+export function isStaticCandidate(value) {
+  return !/[{}]/u.test(value) && !value.includes("<%") && !value.includes("<?");
+}
+
+export function extractAttributes(source) {
+  return [...source.matchAll(attributePattern)]
+    .map((match) => match[4])
+    .filter(isStaticCandidate);
+}
+
+export function splitClassTokens(value) {
+  const tokens = [];
+  let start;
+  let bracketDepth = 0;
+  let bracketQuote;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (bracketDepth > 0) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (bracketQuote) {
+        if (character === bracketQuote) bracketQuote = undefined;
+      } else if (["'", '"', "`"].includes(character)) {
+        bracketQuote = character;
+      } else if (character === "[") {
+        bracketDepth += 1;
+      } else if (character === "]") {
+        bracketDepth -= 1;
+      }
+      if (start === undefined) start = index;
+      continue;
+    }
+
+    if (character === "[") {
+      bracketDepth = 1;
+      if (start === undefined) start = index;
+    } else if (/\s/u.test(character)) {
+      if (start !== undefined) {
+        tokens.push(value.slice(start, index));
+        start = undefined;
+      }
+    } else if (start === undefined) {
+      start = index;
+    }
+  }
+
+  if (start !== undefined) tokens.push(value.slice(start));
+  return tokens;
+}
+
+export function scrambleAttributes(source) {
+  return source.replace(
+    attributePattern,
+    (match, prefix, assignment, quote, value) => {
+      if (!isStaticCandidate(value)) return match;
+      const tokens = splitClassTokens(value);
+      if (tokens.length < 2) return match;
+      return `${prefix}${assignment}${quote}${tokens.reverse().join(" ")}${quote}`;
+    },
+  );
+}
+
+export function same(left, right) {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+export function sameMultiset(left, right) {
+  return same([...left].sort(compareUtf8), [...right].sort(compareUtf8));
+}
+
+export function compareUtf8(left, right) {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}
+
+export function orderCandidates(candidates, limit) {
+  return [...candidates]
+    .filter(({ attributes }) => attributes > 0)
+    .sort(
+      (left, right) =>
+        right.attributes - left.attributes ||
+        compareUtf8(left.path, right.path),
+    )
+    .slice(0, limit);
+}
+
+export function classifyDifference(prettierTokens, rustywindTokens, known) {
+  if (!sameMultiset(prettierTokens, rustywindTokens)) return "token-multiset";
+  if (same(prettierTokens, rustywindTokens)) return "exact";
+
+  const prettierKnown = prettierTokens.filter(
+    (token) => known.get(token) === true,
+  );
+  const rustywindKnown = rustywindTokens.filter(
+    (token) => known.get(token) === true,
+  );
+  return same(prettierKnown, rustywindKnown) ? "custom-only" : "known-order";
+}
+
+export function corpusFingerprint(candidates) {
+  const hash = createHash("sha256");
+  for (const { path, scrambledSource } of candidates) {
+    hash.update(path, "utf8");
+    hash.update("\0", "utf8");
+    hash.update(scrambledSource, "utf8");
+    hash.update("\0", "utf8");
+  }
+  return hash.digest("hex");
+}

--- a/tests/tailwind-compare/package-lock.json
+++ b/tests/tailwind-compare/package-lock.json
@@ -1,0 +1,383 @@
+{
+  "name": "rustywind-tailwind-compare",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rustywind-tailwind-compare",
+      "version": "1.0.0",
+      "dependencies": {
+        "prettier": "3.9.5",
+        "prettier-plugin-astro": "0.14.1",
+        "prettier-plugin-svelte": "3.5.1",
+        "prettier-plugin-tailwindcss": "0.8.0",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sveltejs/acorn-typescript": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+      "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^8.9.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/esrap": {
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.13.tgz",
+      "integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+      "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.9.1",
+        "prettier": "^3.0.0",
+        "sass-formatter": "^0.7.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.1.tgz",
+      "integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
+      "integrity": "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-hermes": "*",
+        "@prettier/plugin-oxc": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-hermes": {
+          "optional": true
+        },
+        "@prettier/plugin-oxc": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "license": "MIT"
+    },
+    "node_modules/sass-formatter": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+      "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "license": "MIT",
+      "dependencies": {
+        "s.color": "0.0.15"
+      }
+    },
+    "node_modules/svelte": {
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.4",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@sveltejs/acorn-typescript": "^1.0.10",
+        "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
+        "acorn": "^8.12.1",
+        "aria-query": "5.3.1",
+        "axobject-query": "^4.1.0",
+        "clsx": "^2.1.1",
+        "devalue": "^5.8.1",
+        "esm-env": "^1.2.1",
+        "esrap": "^2.2.12",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "license": "MIT"
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+      "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+      "license": "MIT",
+      "peer": true
+    }
+  }
+}

--- a/tests/tailwind-compare/package.json
+++ b/tests/tailwind-compare/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "rustywind-tailwind-compare",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "dependencies": {
+    "prettier": "3.9.5",
+    "prettier-plugin-astro": "0.14.1",
+    "prettier-plugin-svelte": "3.5.1",
+    "prettier-plugin-tailwindcss": "0.8.0",
+    "tailwindcss": "4.3.0"
+  }
+}

--- a/tests/tailwind-compare/tailwind.css
+++ b/tests/tailwind-compare/tailwind.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/tests/tailwind-compare/test/compare.test.mjs
+++ b/tests/tailwind-compare/test/compare.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { probeKnownClasses } from "../compare.mjs";
+import { classifyDifference } from "../lib.mjs";
+
+const engineDirectory = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const comparePath = resolve(engineDirectory, "compare.mjs");
+
+test("classifies known-order differences for utilities containing both quotes", async () => {
+  const quotedUtility = `before:content-['hello_"world"']`;
+  const known = await probeKnownClasses(
+    [quotedUtility, "flex"],
+    resolve(engineDirectory, "tailwind.css"),
+  );
+
+  assert.equal(known.get(quotedUtility), true);
+  assert.equal(
+    classifyDifference([quotedUtility, "flex"], ["flex", quotedUtility], known),
+    "known-order",
+  );
+});
+
+test("scrubs configured paths from invocation errors", (context) => {
+  const directory = mkdtempSync(join(tmpdir(), "rustywind-compare-"));
+  context.after(() => rmSync(directory, { force: true, recursive: true }));
+  const repo = join(directory, "repo");
+  const rustywind = join(directory, "rustywind");
+  const output = join(directory, "result.json");
+  mkdirSync(repo);
+  writeFileSync(join(repo, "input.tsx"), '<div className="p-4 flex" />;\n');
+  writeFileSync(
+    rustywind,
+    `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  rm -- "$0"
+  echo "rustywind test"
+fi
+`,
+  );
+  chmodSync(rustywind, 0o755);
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      comparePath,
+      "--corpus",
+      "test",
+      "--repo",
+      repo,
+      "--revision",
+      "test",
+      "--scope",
+      ".",
+      "--kind",
+      "tsx",
+      "--limit",
+      "1",
+      "--rustywind",
+      rustywind,
+      "--stylesheet",
+      resolve(engineDirectory, "tailwind.css"),
+      "--output",
+      output,
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /spawnSync <rustywind> ENOENT/u);
+  assert.equal(result.stderr.includes(directory), false);
+});

--- a/tests/tailwind-compare/test/lib.test.mjs
+++ b/tests/tailwind-compare/test/lib.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import {
+  classifyDifference,
+  corpusFingerprint,
+  extractAttributes,
+  orderCandidates,
+  scrambleAttributes,
+  splitClassTokens,
+} from "../lib.mjs";
+
+test("extracts only static quoted class attributes", () => {
+  const source = `
+    <div class="flex p-4" className = 'grid gap-2'></div>
+    <div className={styles.root} class:list={["p-4"]}></div>
+    <div class="before:content-['{']"></div>
+    <div data-class="ignored"></div>
+  `;
+
+  assert.deepEqual(extractAttributes(source), ["flex p-4", "grid gap-2"]);
+});
+
+test("splits whitespace outside arbitrary-value brackets", () => {
+  const value = String.raw`sm:hover:flex [grid-template-columns:1fr_2fr] content-['hello world'] [--value:'a \' b'] p-4`;
+
+  assert.deepEqual(splitClassTokens(value), [
+    "sm:hover:flex",
+    "[grid-template-columns:1fr_2fr]",
+    "content-['hello world']",
+    String.raw`[--value:'a \' b']`,
+    "p-4",
+  ]);
+});
+
+test("tracks nested brackets and quoted closing brackets", () => {
+  assert.deepEqual(
+    splitClassTokens("[&:has([data-x='[ ]'])]:block  mx-2\tflex"),
+    ["[&:has([data-x='[ ]'])]:block", "mx-2", "flex"],
+  );
+});
+
+test("scrambles eligible attributes without touching dynamic attributes", () => {
+  const source = `<div class="flex  p-4\tmt-2" className={value}><span class='block'></span></div>`;
+
+  assert.equal(
+    scrambleAttributes(source),
+    `<div class="mt-2 p-4 flex" className={value}><span class='block'></span></div>`,
+  );
+});
+
+test("orders candidates by attribute count then UTF-8 path bytes", () => {
+  const candidates = [
+    { path: "z.tsx", attributes: 3 },
+    { path: "é.tsx", attributes: 3 },
+    { path: "a.tsx", attributes: 3 },
+    { path: "many.tsx", attributes: 4 },
+    { path: "empty.tsx", attributes: 0 },
+  ];
+
+  assert.deepEqual(
+    orderCandidates(candidates, 3).map(({ path }) => path),
+    ["many.tsx", "a.tsx", "z.tsx"],
+  );
+});
+
+test("classifies exact, custom-only, known-order, and multiset differences", () => {
+  const known = new Map([
+    ["flex", true],
+    ["p-4", true],
+    ["brand-card", false],
+  ]);
+
+  assert.equal(
+    classifyDifference(["flex", "p-4"], ["flex", "p-4"], known),
+    "exact",
+  );
+  assert.equal(
+    classifyDifference(
+      ["brand-card", "flex", "p-4"],
+      ["flex", "p-4", "brand-card"],
+      known,
+    ),
+    "custom-only",
+  );
+  assert.equal(
+    classifyDifference(["p-4", "flex"], ["flex", "p-4"], known),
+    "known-order",
+  );
+  assert.equal(
+    classifyDifference(["flex", "p-4"], ["flex", "flex"], known),
+    "token-multiset",
+  );
+});
+
+test("fingerprints ordered path and scrambled source records with NUL separators", () => {
+  const records = [
+    { path: "a.tsx", scrambledSource: '<div class="p-4 flex" />' },
+    { path: "nested/b.tsx", scrambledSource: '<p class="mt-2 block">x</p>\n' },
+  ];
+  const expected = createHash("sha256")
+    .update('a.tsx\0<div class="p-4 flex" />\0', "utf8")
+    .update('nested/b.tsx\0<p class="mt-2 block">x</p>\n\0', "utf8")
+    .digest("hex");
+
+  assert.equal(corpusFingerprint(records), expected);
+  assert.notEqual(corpusFingerprint([...records].reverse()), expected);
+});

--- a/tests/tailwind-compare/test/lib.test.mjs
+++ b/tests/tailwind-compare/test/lib.test.mjs
@@ -94,6 +94,18 @@ test("classifies exact, custom-only, known-order, and multiset differences", () 
   );
 });
 
+test("rejects order classification without a result for every token", () => {
+  assert.throws(
+    () =>
+      classifyDifference(
+        ["unclassified", "flex"],
+        ["flex", "unclassified"],
+        new Map([["flex", true]]),
+      ),
+    /missing Tailwind classification for token: "unclassified"/u,
+  );
+});
+
 test("fingerprints ordered path and scrambled source records with NUL separators", () => {
   const records = [
     { path: "a.tsx", scrambledSource: '<div class="p-4 flex" />' },

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -8,6 +8,25 @@ This crate provides developer automation tools for the RustyWind project, replac
 
 ## Available Commands
 
+### compare run
+
+Compare RustyWind against immutable snapshots of real-world Tailwind projects.
+
+```bash
+# compare every corpus
+cargo xtask compare run
+
+# compare selected corpora
+cargo xtask compare run --corpus shadcn-ui --corpus astrowind
+
+# reuse cached repositories and npm packages without network access
+cargo xtask compare run --offline
+```
+
+The command builds the release binary, installs the pinned comparison harness with
+`npm ci`, checks out each corpus at its exact revision, and writes aggregate reports
+to `target/tailwind-compare/results/`.
+
 ### fuzz setup
 
 Set up the fuzz test environment by building the RustyWind release binary and installing npm dependencies.
@@ -64,7 +83,8 @@ cargo xtask fuzz run 50 --workers 4
 ## Prerequisites
 
 Commands require:
-- Node.js and npm installed (system-wide)
+- Node.js 20.19 or newer and npm installed system-wide
+- Git for the real-world comparison corpora
 
 The `fuzz run` command automatically ensures that:
 - RustyWind binary is built (`cargo build --release`)
@@ -81,6 +101,8 @@ xtask/
 ├── src/
 │   ├── main.rs              # CLI entry point with clap
 │   ├── commands/            # Command implementations
+│   │   ├── compare.rs       # pinned real-world Tailwind comparisons
+│   │   ├── npm.rs           # npm package publishing
 │   │   ├── setup.rs         # setup command
 │   │   └── run.rs           # run command with integrated analysis
 │   └── utils/               # Shared utilities
@@ -128,7 +150,7 @@ cargo test --package xtask
 
 1. Create new file in `src/commands/`
 2. Implement `pub fn run(...) -> Result<()>`
-3. Add module to `src/commands/mod.rs`
+3. Add the module to `src/commands.rs`
 4. Add variant to appropriate enum in `src/main.rs`
 5. Add match arm in the match expression
 

--- a/xtask/src/commands.rs
+++ b/xtask/src/commands.rs
@@ -1,3 +1,4 @@
+pub mod compare;
 pub mod npm;
 pub mod run;
 pub mod setup;

--- a/xtask/src/commands/compare.rs
+++ b/xtask/src/commands/compare.rs
@@ -155,8 +155,44 @@ struct CompareRunner {
     harness: PathBuf,
     output_directory: PathBuf,
     repository_directory: PathBuf,
-    rustywind: PathBuf,
     offline: bool,
+}
+
+struct RustywindBinary(PathBuf);
+
+impl RustywindBinary {
+    fn build(workspace: &Path, offline: bool) -> Result<Self> {
+        let mut build = Command::new("cargo");
+        build.current_dir(workspace).args([
+            "build",
+            "--release",
+            "--package",
+            "rustywind",
+            "--bin",
+            "rustywind",
+            "--message-format=json-render-diagnostics",
+        ]);
+        if offline {
+            build.arg("--offline");
+        }
+
+        let output = build
+            .output()
+            .wrap_err("failed to build the RustyWind release binary")?;
+        let output = checked_output(output, "build the RustyWind release binary")?;
+        let binary = Self(resolve_rustywind_binary(&output.stdout)?);
+        if !binary.0.is_file() {
+            bail!(
+                "RustyWind release build reported a missing executable at {}",
+                binary.0.display()
+            );
+        }
+        Ok(binary)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
 }
 
 impl CompareRunner {
@@ -169,7 +205,6 @@ impl CompareRunner {
         let target = workspace.join("target/tailwind-compare");
 
         Ok(Self {
-            rustywind: workspace.join("target/release/rustywind"),
             repository_directory: target.join("repos"),
             output_directory: target.join("results"),
             workspace,
@@ -193,23 +228,26 @@ impl CompareRunner {
             )
         })?;
 
-        if let Err(error) = self.prepare_environment() {
-            eprintln!("Comparison setup failed: {error:#}");
-            let results = selected
-                .into_iter()
-                .map(|spec| CorpusRunResult::failed(spec, FailureReason::Setup))
-                .collect();
-            let summary = ComparisonSummary::new(results);
-            self.write_summary(&summary)?;
-            self.print_summary(&summary);
-            bail!(
-                "Tailwind comparison setup failed; see target/tailwind-compare/results/report.md"
-            );
-        }
+        let rustywind = match self.prepare_environment() {
+            Ok(rustywind) => rustywind,
+            Err(error) => {
+                eprintln!("Comparison setup failed: {error:#}");
+                let results = selected
+                    .into_iter()
+                    .map(|spec| CorpusRunResult::failed(spec, FailureReason::Setup))
+                    .collect();
+                let summary = ComparisonSummary::new(results);
+                self.write_summary(&summary)?;
+                self.print_summary(&summary);
+                bail!(
+                    "Tailwind comparison setup failed; see target/tailwind-compare/results/report.md"
+                );
+            }
+        };
 
         let results = selected
             .into_iter()
-            .map(|spec| self.run_corpus(spec))
+            .map(|spec| self.run_corpus(spec, &rustywind))
             .collect::<Vec<_>>();
         let summary = ComparisonSummary::new(results);
         self.write_summary(&summary)?;
@@ -222,18 +260,11 @@ impl CompareRunner {
         Ok(())
     }
 
-    fn prepare_environment(&self) -> Result<()> {
+    fn prepare_environment(&self) -> Result<RustywindBinary> {
         validate_prerequisites()?;
         validate_harness(&self.harness)?;
 
-        let mut build = Command::new("cargo");
-        build
-            .current_dir(&self.workspace)
-            .args(["build", "--release", "--package", "rustywind"]);
-        if self.offline {
-            build.arg("--offline");
-        }
-        let build_result = run_checked(&mut build, "build the RustyWind release binary");
+        let build_result = RustywindBinary::build(&self.workspace, self.offline);
 
         let mut npm = Command::new("npm");
         npm.current_dir(&self.harness).arg("ci");
@@ -252,17 +283,10 @@ impl CompareRunner {
             bail!("comparison environment preparation failed");
         }
 
-        if !self.rustywind.is_file() {
-            bail!(
-                "RustyWind release build did not produce {}",
-                self.rustywind.display()
-            );
-        }
-
-        Ok(())
+        build_result
     }
 
-    fn run_corpus(&self, spec: CorpusSpec) -> CorpusRunResult {
+    fn run_corpus(&self, spec: CorpusSpec, rustywind: &RustywindBinary) -> CorpusRunResult {
         println!("Comparing {} at {}", spec.name, spec.revision);
 
         let repository = match self.prepare_repository(spec) {
@@ -271,7 +295,7 @@ impl CompareRunner {
                 return failed_corpus(spec, FailureReason::RepositoryUnavailable, error);
             }
         };
-        let report = match self.invoke_comparison(spec, &repository) {
+        let report = match self.invoke_comparison(spec, &repository, rustywind) {
             Ok(report) => report,
             Err(error) => return failed_corpus(spec, FailureReason::InvocationFailed, error),
         };
@@ -369,7 +393,12 @@ impl CompareRunner {
         run_checked(&mut add_remote, "configure corpus remote")
     }
 
-    fn invoke_comparison(&self, spec: CorpusSpec, repository: &Path) -> Result<NodeReport> {
+    fn invoke_comparison(
+        &self,
+        spec: CorpusSpec,
+        repository: &Path,
+        rustywind: &RustywindBinary,
+    ) -> Result<NodeReport> {
         let output_path = self
             .output_directory
             .join(format!("{}.json", spec.name.as_str()));
@@ -390,7 +419,7 @@ impl CompareRunner {
             .args(["--kind", spec.kind.as_str()])
             .args(["--limit", &spec.limit.to_string()])
             .args(["--rustywind"])
-            .arg(&self.rustywind)
+            .arg(rustywind.path())
             .args(["--stylesheet"])
             .arg(self.harness.join("tailwind.css"))
             .args(["--output"])
@@ -514,6 +543,60 @@ fn validate_exact_revision(expected: &str, actual: &str) -> Result<()> {
         bail!("corpus revision mismatch: expected {expected}, found {actual}");
     }
     Ok(())
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "reason", rename_all = "kebab-case")]
+enum CargoBuildMessage {
+    CompilerArtifact {
+        target: CargoTarget,
+        executable: Option<PathBuf>,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize)]
+struct CargoTarget {
+    name: String,
+    kind: Vec<CargoTargetKind>,
+}
+
+#[derive(Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+enum CargoTargetKind {
+    Bin,
+    #[serde(other)]
+    Other,
+}
+
+fn resolve_rustywind_binary(build_output: &[u8]) -> Result<PathBuf> {
+    let build_output =
+        std::str::from_utf8(build_output).wrap_err("Cargo build output was not valid UTF-8")?;
+    let mut executables = build_output
+        .lines()
+        .map(serde_json::from_str::<CargoBuildMessage>)
+        .collect::<serde_json::Result<Vec<_>>>()?
+        .into_iter()
+        .filter_map(|message| match message {
+            CargoBuildMessage::CompilerArtifact { target, executable }
+                if target.name == "rustywind" && target.kind.contains(&CargoTargetKind::Bin) =>
+            {
+                executable
+            }
+            CargoBuildMessage::CompilerArtifact { .. } | CargoBuildMessage::Other => None,
+        });
+    let executable = executables
+        .next()
+        .ok_or_else(|| eyre!("Cargo did not report the RustyWind executable artifact"))?;
+    if let Some(other) = executables.next() {
+        bail!(
+            "Cargo reported multiple RustyWind executable artifacts: {} and {}",
+            executable.display(),
+            other.display()
+        );
+    }
+    Ok(executable)
 }
 
 fn command_stdout(command: &mut Command, description: &str) -> Result<String> {
@@ -1220,6 +1303,22 @@ mod tests {
     use super::*;
 
     const FINGERPRINT: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn binary_resolution_uses_cargo_reported_executable() {
+        let expected = PathBuf::from(
+            "/custom-target/aarch64-unknown-linux-gnu/release/rustywind-custom-suffix",
+        );
+        let output = format!(
+            "{{\"reason\":\"compiler-artifact\",\"target\":{{\"name\":\"rustywind_core\",\"kind\":[\"lib\"]}},\"executable\":null}}\n{{\"reason\":\"compiler-artifact\",\"target\":{{\"name\":\"rustywind\",\"kind\":[\"bin\"]}},\"executable\":{}}}\n{{\"reason\":\"build-finished\",\"success\":true}}\n",
+            serde_json::to_string(&expected).unwrap()
+        );
+
+        assert_eq!(
+            resolve_rustywind_binary(output.as_bytes()).unwrap(),
+            expected
+        );
+    }
 
     #[test]
     fn empty_selection_uses_every_corpus_in_canonical_order() {

--- a/xtask/src/commands/compare.rs
+++ b/xtask/src/commands/compare.rs
@@ -1,0 +1,1424 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fmt, fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use clap::ValueEnum;
+use color_eyre::{
+    Result,
+    eyre::{Context, bail, eyre},
+};
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+
+const REPORT_SCHEMA_VERSION: u32 = 1;
+const MINIMUM_NODE_VERSION: &str = ">=20.19.0";
+
+/// A pinned real-world Tailwind corpus.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ValueEnum)]
+pub(crate) enum CorpusName {
+    #[value(name = "shadcn-ui")]
+    ShadcnUi,
+    #[value(name = "shadcn-svelte")]
+    ShadcnSvelte,
+    Astrowind,
+}
+
+impl CorpusName {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ShadcnUi => "shadcn-ui",
+            Self::ShadcnSvelte => "shadcn-svelte",
+            Self::Astrowind => "astrowind",
+        }
+    }
+}
+
+impl fmt::Display for CorpusName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CorpusKind {
+    Tsx,
+    Svelte,
+    Astro,
+}
+
+impl CorpusKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Tsx => "tsx",
+            Self::Svelte => "svelte",
+            Self::Astro => "astro",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ExpectedCorpus {
+    files: u64,
+    attributes: u64,
+    fingerprint: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CorpusSpec {
+    name: CorpusName,
+    repository: &'static str,
+    revision: &'static str,
+    scope: &'static str,
+    kind: CorpusKind,
+    limit: u64,
+    expected: ExpectedCorpus,
+}
+
+impl CorpusSpec {
+    const fn new(
+        name: CorpusName,
+        repository: &'static str,
+        revision: &'static str,
+        scope: &'static str,
+        kind: CorpusKind,
+        limit: u64,
+        expected: ExpectedCorpus,
+    ) -> Self {
+        Self {
+            name,
+            repository,
+            revision,
+            scope,
+            kind,
+            limit,
+            expected,
+        }
+    }
+
+    fn repository_url(self) -> String {
+        format!("https://github.com/{}.git", self.repository)
+    }
+}
+
+// update these fingerprints after intentionally refreshing the pinned corpus reports
+const CORPORA: [CorpusSpec; 3] = [
+    CorpusSpec::new(
+        CorpusName::ShadcnUi,
+        "shadcn-ui/ui",
+        "bb8ba0daceb717eefc3a6ecb3457f28ca770d138",
+        "apps/v4/app",
+        CorpusKind::Tsx,
+        40,
+        ExpectedCorpus {
+            files: 40,
+            attributes: 834,
+            fingerprint: "bf5e7fd497e6cfef0cccbc852d281a53b5d60a6f0e7ffd966ab7984b0259d0da",
+        },
+    ),
+    CorpusSpec::new(
+        CorpusName::ShadcnSvelte,
+        "huntabyte/shadcn-svelte",
+        "efcf8a4ef2c6a3a21ee2fd4db905519f8d4c8e63",
+        "docs/src/lib/registry/examples",
+        CorpusKind::Svelte,
+        40,
+        ExpectedCorpus {
+            files: 40,
+            attributes: 717,
+            fingerprint: "2b1e23a82fff982fe3f270a2cefaffeac3290c2fc640a656dd77a176bf13d80e",
+        },
+    ),
+    CorpusSpec::new(
+        CorpusName::Astrowind,
+        "onwidget/astrowind",
+        "522530a242f5855f22a44a001f7b2e199669073d",
+        "src",
+        CorpusKind::Astro,
+        53,
+        ExpectedCorpus {
+            files: 53,
+            attributes: 379,
+            fingerprint: "7045db395ba1d01792b2731e78c94744745a9e6da56a6920fdd71efde752ac3e",
+        },
+    ),
+];
+
+pub(crate) fn run(requested: &[CorpusName], offline: bool) -> Result<()> {
+    CompareRunner::new(offline)?.run(requested)
+}
+
+struct CompareRunner {
+    workspace: PathBuf,
+    harness: PathBuf,
+    output_directory: PathBuf,
+    repository_directory: PathBuf,
+    rustywind: PathBuf,
+    offline: bool,
+}
+
+impl CompareRunner {
+    fn new(offline: bool) -> Result<Self> {
+        let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .ok_or_else(|| eyre!("xtask manifest directory has no workspace parent"))?
+            .to_path_buf();
+        let harness = workspace.join("tests/tailwind-compare");
+        let target = workspace.join("target/tailwind-compare");
+
+        Ok(Self {
+            rustywind: workspace.join("target/release/rustywind"),
+            repository_directory: target.join("repos"),
+            output_directory: target.join("results"),
+            workspace,
+            harness,
+            offline,
+        })
+    }
+
+    fn run(&self, requested: &[CorpusName]) -> Result<()> {
+        let selected = select_corpora(requested);
+        fs::create_dir_all(&self.repository_directory).wrap_err_with(|| {
+            format!(
+                "failed to create repository cache {}",
+                self.repository_directory.display()
+            )
+        })?;
+        fs::create_dir_all(&self.output_directory).wrap_err_with(|| {
+            format!(
+                "failed to create result directory {}",
+                self.output_directory.display()
+            )
+        })?;
+
+        if let Err(error) = self.prepare_environment() {
+            eprintln!("Comparison setup failed: {error:#}");
+            let results = selected
+                .into_iter()
+                .map(|spec| CorpusRunResult::failed(spec, FailureReason::Setup))
+                .collect();
+            let summary = ComparisonSummary::new(results);
+            self.write_summary(&summary)?;
+            self.print_summary(&summary);
+            bail!(
+                "Tailwind comparison setup failed; see target/tailwind-compare/results/report.md"
+            );
+        }
+
+        let results = selected
+            .into_iter()
+            .map(|spec| self.run_corpus(spec))
+            .collect::<Vec<_>>();
+        let summary = ComparisonSummary::new(results);
+        self.write_summary(&summary)?;
+        self.print_summary(&summary);
+
+        if summary.status == AggregateStatus::Failed {
+            bail!("Tailwind comparison failed; see target/tailwind-compare/results/report.md");
+        }
+
+        Ok(())
+    }
+
+    fn prepare_environment(&self) -> Result<()> {
+        validate_prerequisites()?;
+        validate_harness(&self.harness)?;
+
+        let mut build = Command::new("cargo");
+        build
+            .current_dir(&self.workspace)
+            .args(["build", "--release", "--package", "rustywind"]);
+        if self.offline {
+            build.arg("--offline");
+        }
+        let build_result = run_checked(&mut build, "build the RustyWind release binary");
+
+        let mut npm = Command::new("npm");
+        npm.current_dir(&self.harness).arg("ci");
+        if self.offline {
+            npm.arg("--offline").env("npm_config_offline", "true");
+        }
+        let npm_result = run_checked(&mut npm, "install comparison harness dependencies");
+
+        if let Err(error) = &build_result {
+            eprintln!("RustyWind build failed: {error:#}");
+        }
+        if let Err(error) = &npm_result {
+            eprintln!("Comparison dependency installation failed: {error:#}");
+        }
+        if build_result.is_err() || npm_result.is_err() {
+            bail!("comparison environment preparation failed");
+        }
+
+        if !self.rustywind.is_file() {
+            bail!(
+                "RustyWind release build did not produce {}",
+                self.rustywind.display()
+            );
+        }
+
+        Ok(())
+    }
+
+    fn run_corpus(&self, spec: CorpusSpec) -> CorpusRunResult {
+        println!("Comparing {} at {}", spec.name, spec.revision);
+
+        let repository = match self.prepare_repository(spec) {
+            Ok(repository) => repository,
+            Err(error) => {
+                return failed_corpus(spec, FailureReason::RepositoryUnavailable, error);
+            }
+        };
+        let report = match self.invoke_comparison(spec, &repository) {
+            Ok(report) => report,
+            Err(error) => return failed_corpus(spec, FailureReason::InvocationFailed, error),
+        };
+        let report = match validate_report(spec, report) {
+            Ok(report) => report,
+            Err(error) => return failed_corpus(spec, FailureReason::InvalidReport, error),
+        };
+        CorpusRunResult::from_report(spec, &report)
+    }
+
+    fn prepare_repository(&self, spec: CorpusSpec) -> Result<PathBuf> {
+        let repository = self.repository_directory.join(spec.name.as_str());
+        if !repository.exists() {
+            if self.offline {
+                bail!(
+                    "{} is not cached; rerun without --offline to fetch it",
+                    spec.name
+                );
+            }
+            let mut init = Command::new("git");
+            init.args(["init", "--quiet"]).arg(&repository);
+            run_checked(&mut init, "initialize corpus repository")?;
+        }
+
+        validate_git_repository(&repository)?;
+        ensure_clean_repository(&repository)?;
+
+        if !self.offline {
+            self.configure_remote(&repository, spec)?;
+            let mut fetch = Command::new("git");
+            fetch.current_dir(&repository).args([
+                "fetch",
+                "--quiet",
+                "--depth=1",
+                "origin",
+                spec.revision,
+            ]);
+            run_checked(&mut fetch, "fetch pinned corpus revision")?;
+        }
+
+        let mut checkout = Command::new("git");
+        checkout
+            .current_dir(&repository)
+            .args(["checkout", "--quiet", "--detach", spec.revision]);
+        run_checked(&mut checkout, "check out pinned corpus revision")?;
+
+        let actual_revision = command_stdout(
+            Command::new("git")
+                .current_dir(&repository)
+                .args(["rev-parse", "HEAD"]),
+            "read corpus revision",
+        )?;
+        validate_exact_revision(spec.revision, actual_revision.trim())?;
+
+        let branch = command_stdout(
+            Command::new("git").current_dir(&repository).args([
+                "rev-parse",
+                "--abbrev-ref",
+                "HEAD",
+            ]),
+            "verify detached corpus checkout",
+        )?;
+        if branch.trim() != "HEAD" {
+            bail!("{} checkout is attached to branch {branch}", spec.name);
+        }
+
+        Ok(repository)
+    }
+
+    fn configure_remote(&self, repository: &Path, spec: CorpusSpec) -> Result<()> {
+        let expected_url = spec.repository_url();
+        let output = Command::new("git")
+            .current_dir(repository)
+            .args(["remote", "get-url", "origin"])
+            .output()
+            .wrap_err("failed to inspect corpus remote")?;
+
+        if output.status.success() {
+            let actual_url = String::from_utf8(output.stdout)
+                .wrap_err("corpus remote URL was not valid UTF-8")?;
+            if actual_url.trim() != expected_url {
+                bail!(
+                    "{} cache has unexpected origin URL {}; expected {expected_url}",
+                    spec.name,
+                    actual_url.trim()
+                );
+            }
+            return Ok(());
+        }
+
+        let mut add_remote = Command::new("git");
+        add_remote
+            .current_dir(repository)
+            .args(["remote", "add", "origin", &expected_url]);
+        run_checked(&mut add_remote, "configure corpus remote")
+    }
+
+    fn invoke_comparison(&self, spec: CorpusSpec, repository: &Path) -> Result<NodeReport> {
+        let output_path = self
+            .output_directory
+            .join(format!("{}.json", spec.name.as_str()));
+        if output_path.exists() {
+            fs::remove_file(&output_path).wrap_err_with(|| {
+                format!("failed to remove stale report {}", output_path.display())
+            })?;
+        }
+
+        let mut node = Command::new("node");
+        node.current_dir(&self.harness)
+            .arg("compare.mjs")
+            .args(["--corpus", spec.name.as_str()])
+            .args(["--repo"])
+            .arg(repository)
+            .args(["--revision", spec.revision])
+            .args(["--scope", spec.scope])
+            .args(["--kind", spec.kind.as_str()])
+            .args(["--limit", &spec.limit.to_string()])
+            .args(["--rustywind"])
+            .arg(&self.rustywind)
+            .args(["--stylesheet"])
+            .arg(self.harness.join("tailwind.css"))
+            .args(["--output"])
+            .arg(&output_path);
+        run_checked(&mut node, "run corpus comparison")?;
+
+        let report = fs::read_to_string(&output_path)
+            .wrap_err_with(|| format!("failed to read report {}", output_path.display()))?;
+        serde_json::from_str(&report)
+            .wrap_err_with(|| format!("failed to parse report {}", output_path.display()))
+    }
+
+    fn write_summary(&self, summary: &ComparisonSummary) -> Result<()> {
+        let json = serde_json::to_string_pretty(summary)
+            .wrap_err("failed to serialize comparison summary")?;
+        fs::write(
+            self.output_directory.join("summary.json"),
+            format!("{json}\n"),
+        )
+        .wrap_err("failed to write comparison summary JSON")?;
+        fs::write(self.output_directory.join("report.md"), summary.markdown())
+            .wrap_err("failed to write comparison Markdown report")
+    }
+
+    fn print_summary(&self, summary: &ComparisonSummary) {
+        println!();
+        println!("Tailwind comparison: {}", summary.status);
+        for corpus in &summary.corpora {
+            println!("  {} {}: {}", corpus.name, corpus.revision, corpus.status);
+        }
+        println!("Results: target/tailwind-compare/results/report.md");
+    }
+}
+
+fn failed_corpus(
+    spec: CorpusSpec,
+    reason: FailureReason,
+    error: color_eyre::Report,
+) -> CorpusRunResult {
+    eprintln!("{} failed: {error:#}", spec.name);
+    CorpusRunResult::failed(spec, reason)
+}
+
+fn select_corpora(requested: &[CorpusName]) -> Vec<CorpusSpec> {
+    if requested.is_empty() {
+        return CORPORA.to_vec();
+    }
+
+    let requested = requested.iter().copied().collect::<HashSet<_>>();
+    CORPORA
+        .iter()
+        .copied()
+        .filter(|spec| requested.contains(&spec.name))
+        .collect()
+}
+
+fn validate_prerequisites() -> Result<()> {
+    for executable in ["cargo", "git", "node", "npm"] {
+        which::which(executable)
+            .wrap_err_with(|| format!("required executable `{executable}` was not found"))?;
+    }
+
+    let version = command_stdout(
+        Command::new("node").arg("--version"),
+        "read Node.js version",
+    )?;
+    let version = Version::parse(version.trim().trim_start_matches('v'))
+        .wrap_err_with(|| format!("Node.js returned an invalid version: {version:?}"))?;
+    let requirement = VersionReq::parse(MINIMUM_NODE_VERSION)
+        .wrap_err("invalid built-in Node.js version requirement")?;
+    if !requirement.matches(&version) {
+        bail!("Node.js {MINIMUM_NODE_VERSION} is required; found {version}");
+    }
+
+    Ok(())
+}
+
+fn validate_harness(harness: &Path) -> Result<()> {
+    for relative in [
+        "compare.mjs",
+        "package.json",
+        "package-lock.json",
+        "tailwind.css",
+    ] {
+        let path = harness.join(relative);
+        if !path.is_file() {
+            bail!("comparison harness is missing {relative}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_git_repository(repository: &Path) -> Result<()> {
+    let inside_work_tree = command_stdout(
+        Command::new("git")
+            .current_dir(repository)
+            .args(["rev-parse", "--is-inside-work-tree"]),
+        "validate corpus repository",
+    )?;
+    if inside_work_tree.trim() != "true" {
+        bail!("corpus cache is not a Git work tree");
+    }
+    Ok(())
+}
+
+fn ensure_clean_repository(repository: &Path) -> Result<()> {
+    let status = command_stdout(
+        Command::new("git")
+            .current_dir(repository)
+            .args(["status", "--porcelain"]),
+        "inspect corpus repository status",
+    )?;
+    if !status.trim().is_empty() {
+        bail!("corpus cache has local changes");
+    }
+    Ok(())
+}
+
+fn validate_exact_revision(expected: &str, actual: &str) -> Result<()> {
+    if actual != expected {
+        bail!("corpus revision mismatch: expected {expected}, found {actual}");
+    }
+    Ok(())
+}
+
+fn command_stdout(command: &mut Command, description: &str) -> Result<String> {
+    let output = command
+        .output()
+        .wrap_err_with(|| format!("failed to {description}"))?;
+    checked_output(output, description).and_then(|output| {
+        String::from_utf8(output.stdout)
+            .wrap_err_with(|| format!("{description} returned non-UTF-8 output"))
+    })
+}
+
+fn run_checked(command: &mut Command, description: &str) -> Result<()> {
+    let output = command
+        .output()
+        .wrap_err_with(|| format!("failed to {description}"))?;
+    checked_output(output, description).map(|_| ())
+}
+
+fn checked_output(output: Output, description: &str) -> Result<Output> {
+    if output.status.success() {
+        return Ok(output);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = if stderr.trim().is_empty() {
+        stdout.trim()
+    } else {
+        stderr.trim()
+    };
+    bail!("failed to {description}: {detail}");
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NodeReport {
+    schema_version: u32,
+    corpus: ReportCorpus,
+    versions: ToolVersions,
+    summary: ReportSummary,
+    candidates: Vec<Candidate>,
+    details: Vec<ComparisonDetail>,
+    failures: Vec<ReportFailure>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReportCorpus {
+    name: String,
+    revision: String,
+    scope: String,
+    kind: String,
+    limit: u64,
+    files: u64,
+    attributes: u64,
+    fingerprint: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ToolVersions {
+    prettier: String,
+    prettier_plugin_tailwindcss: String,
+    tailwindcss: String,
+    prettier_plugin_astro: String,
+    prettier_plugin_svelte: String,
+}
+
+impl ToolVersions {
+    fn validate(&self) -> Result<()> {
+        for (name, version) in [
+            ("prettier", self.prettier.as_str()),
+            (
+                "prettierPluginTailwindcss",
+                self.prettier_plugin_tailwindcss.as_str(),
+            ),
+            ("tailwindcss", self.tailwindcss.as_str()),
+            ("prettierPluginAstro", self.prettier_plugin_astro.as_str()),
+            ("prettierPluginSvelte", self.prettier_plugin_svelte.as_str()),
+        ] {
+            if version.trim().is_empty() {
+                bail!("report has an empty {name} version");
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReportSummary {
+    prettier_changed: u64,
+    rustywind_changed: u64,
+    exact: u64,
+    custom_only: u64,
+    known_order_mismatch: u64,
+    extraction_mismatch: u64,
+    failures: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct Candidate {
+    path: String,
+    attributes: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "kebab-case",
+    rename_all_fields = "camelCase"
+)]
+enum ComparisonDetail {
+    AttributeCount {
+        path: String,
+        expected: u64,
+        original: u64,
+        prettier: u64,
+        rustywind: u64,
+    },
+    TokenMultiset {
+        path: String,
+        attribute: u64,
+        original: Vec<String>,
+        prettier: Vec<String>,
+        rustywind: Vec<String>,
+    },
+    CustomOnly {
+        path: String,
+        attribute: u64,
+        original: Vec<String>,
+        prettier: Vec<String>,
+        rustywind: Vec<String>,
+        prettier_unknown: Vec<String>,
+    },
+    KnownOrder {
+        path: String,
+        attribute: u64,
+        original: Vec<String>,
+        prettier: Vec<String>,
+        rustywind: Vec<String>,
+        prettier_unknown: Vec<String>,
+    },
+}
+
+impl ComparisonDetail {
+    fn path(&self) -> &str {
+        match self {
+            Self::AttributeCount { path, .. }
+            | Self::TokenMultiset { path, .. }
+            | Self::CustomOnly { path, .. }
+            | Self::KnownOrder { path, .. } => path,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ReportFailure {
+    path: String,
+    stage: String,
+    error: String,
+}
+
+fn validate_report(spec: CorpusSpec, report: NodeReport) -> Result<NodeReport> {
+    if report.schema_version != REPORT_SCHEMA_VERSION {
+        bail!(
+            "unsupported report schema version {}; expected {REPORT_SCHEMA_VERSION}",
+            report.schema_version
+        );
+    }
+    validate_report_metadata(spec, &report.corpus)?;
+    report.versions.validate()?;
+    validate_candidates(&report)?;
+    validate_details(&report)?;
+    validate_failures(&report)?;
+    validate_fingerprint(spec.expected.fingerprint, &report.corpus.fingerprint)?;
+    Ok(report)
+}
+
+fn validate_report_metadata(spec: CorpusSpec, actual: &ReportCorpus) -> Result<()> {
+    let expected = [
+        ("name", spec.name.as_str(), actual.name.as_str()),
+        ("revision", spec.revision, actual.revision.as_str()),
+        ("scope", spec.scope, actual.scope.as_str()),
+        ("kind", spec.kind.as_str(), actual.kind.as_str()),
+    ];
+    for (field, expected, actual) in expected {
+        if actual != expected {
+            bail!("report {field} mismatch: expected {expected}, found {actual}");
+        }
+    }
+    if actual.limit != spec.limit {
+        bail!(
+            "report limit mismatch: expected {}, found {}",
+            spec.limit,
+            actual.limit
+        );
+    }
+    if actual.files != spec.expected.files {
+        bail!(
+            "report file count mismatch: expected {}, found {}",
+            spec.expected.files,
+            actual.files
+        );
+    }
+    if actual.attributes != spec.expected.attributes {
+        bail!(
+            "report attribute count mismatch: expected {}, found {}",
+            spec.expected.attributes,
+            actual.attributes
+        );
+    }
+    Ok(())
+}
+
+fn validate_candidates(report: &NodeReport) -> Result<()> {
+    if report.candidates.len() as u64 != report.corpus.files {
+        bail!(
+            "candidate count mismatch: metadata says {}, report contains {}",
+            report.corpus.files,
+            report.candidates.len()
+        );
+    }
+
+    let mut paths = HashSet::new();
+    let mut attributes = 0_u64;
+    for candidate in &report.candidates {
+        let path = Path::new(&candidate.path);
+        if path.is_absolute() || candidate.path.trim().is_empty() {
+            bail!("candidate path must be a non-empty repository-relative path");
+        }
+        if !paths.insert(candidate.path.as_str()) {
+            bail!("candidate path appears more than once: {}", candidate.path);
+        }
+        attributes = attributes
+            .checked_add(candidate.attributes)
+            .ok_or_else(|| eyre!("candidate attribute count overflow"))?;
+    }
+    if attributes != report.corpus.attributes {
+        bail!(
+            "candidate attribute count mismatch: metadata says {}, candidates contain {attributes}",
+            report.corpus.attributes
+        );
+    }
+
+    if report.summary.prettier_changed > report.corpus.attributes
+        || report.summary.rustywind_changed > report.corpus.attributes
+    {
+        bail!("summary changed count exceeds corpus attributes");
+    }
+    Ok(())
+}
+
+fn validate_details(report: &NodeReport) -> Result<()> {
+    let candidate_attributes = report
+        .candidates
+        .iter()
+        .map(|candidate| (candidate.path.as_str(), candidate.attributes))
+        .collect::<HashMap<_, _>>();
+    let mut attribute_details = HashSet::new();
+    let mut whole_file_details = HashSet::new();
+    let mut custom_only = 0_u64;
+    let mut known_order = 0_u64;
+    let mut extraction = 0_u64;
+
+    for detail in &report.details {
+        let path = detail.path();
+        if Path::new(path).is_absolute() || path.trim().is_empty() {
+            bail!("report contains an invalid detail path");
+        }
+        let candidate_attributes = *candidate_attributes
+            .get(path)
+            .ok_or_else(|| eyre!("detail refers to a file outside the candidate set"))?;
+
+        match detail {
+            ComparisonDetail::AttributeCount {
+                expected,
+                original,
+                prettier,
+                rustywind,
+                ..
+            } => {
+                if *expected != candidate_attributes {
+                    bail!("attribute-count detail does not match candidate metadata");
+                }
+                if original == expected && prettier == expected && rustywind == expected {
+                    bail!("attribute-count detail does not describe a mismatch");
+                }
+                if !whole_file_details.insert(path) {
+                    bail!("candidate has more than one attribute-count detail");
+                }
+                extraction = extraction
+                    .checked_add(*expected)
+                    .ok_or_else(|| eyre!("detail extraction count overflow"))?;
+            }
+            ComparisonDetail::TokenMultiset {
+                attribute,
+                original,
+                prettier,
+                rustywind,
+                ..
+            } => {
+                validate_attribute_detail(
+                    path,
+                    *attribute,
+                    candidate_attributes,
+                    original,
+                    prettier,
+                    rustywind,
+                    &mut attribute_details,
+                )?;
+                extraction = extraction
+                    .checked_add(1)
+                    .ok_or_else(|| eyre!("detail extraction count overflow"))?;
+            }
+            ComparisonDetail::CustomOnly {
+                attribute,
+                original,
+                prettier,
+                rustywind,
+                prettier_unknown,
+                ..
+            } => {
+                validate_attribute_detail(
+                    path,
+                    *attribute,
+                    candidate_attributes,
+                    original,
+                    prettier,
+                    rustywind,
+                    &mut attribute_details,
+                )?;
+                validate_unknown_tokens(prettier_unknown, rustywind)?;
+                custom_only = custom_only
+                    .checked_add(1)
+                    .ok_or_else(|| eyre!("custom-only detail count overflow"))?;
+            }
+            ComparisonDetail::KnownOrder {
+                attribute,
+                original,
+                prettier,
+                rustywind,
+                prettier_unknown,
+                ..
+            } => {
+                validate_attribute_detail(
+                    path,
+                    *attribute,
+                    candidate_attributes,
+                    original,
+                    prettier,
+                    rustywind,
+                    &mut attribute_details,
+                )?;
+                validate_unknown_tokens(prettier_unknown, rustywind)?;
+                known_order = known_order
+                    .checked_add(1)
+                    .ok_or_else(|| eyre!("known-order detail count overflow"))?;
+            }
+        }
+    }
+
+    if attribute_details
+        .iter()
+        .any(|(path, _)| whole_file_details.contains(path.as_str()))
+    {
+        bail!("attribute-count detail overlaps per-attribute details for the same candidate");
+    }
+    if custom_only != report.summary.custom_only
+        || known_order != report.summary.known_order_mismatch
+        || extraction != report.summary.extraction_mismatch
+    {
+        bail!("detail classifications do not match report summary");
+    }
+    Ok(())
+}
+
+fn validate_attribute_detail(
+    path: &str,
+    attribute: u64,
+    candidate_attributes: u64,
+    original: &[String],
+    prettier: &[String],
+    rustywind: &[String],
+    seen: &mut HashSet<(String, u64)>,
+) -> Result<()> {
+    if attribute >= candidate_attributes {
+        bail!("detail attribute index is outside its candidate");
+    }
+    if prettier == rustywind {
+        bail!("comparison detail does not describe a mismatch");
+    }
+    if original.iter().any(|token| token.contains('\0'))
+        || prettier.iter().any(|token| token.contains('\0'))
+        || rustywind.iter().any(|token| token.contains('\0'))
+    {
+        bail!("comparison detail contains an invalid class token");
+    }
+    if !seen.insert((path.to_string(), attribute)) {
+        bail!("candidate attribute appears in more than one detail");
+    }
+    Ok(())
+}
+
+fn validate_unknown_tokens(unknown: &[String], rustywind: &[String]) -> Result<()> {
+    if unknown.iter().any(|token| !rustywind.contains(token)) {
+        bail!("detail unknown token is absent from the RustyWind tokens");
+    }
+    Ok(())
+}
+
+fn validate_failures(report: &NodeReport) -> Result<()> {
+    if report.failures.len() as u64 != report.summary.failures {
+        bail!(
+            "failure count mismatch: summary says {}, report contains {}",
+            report.summary.failures,
+            report.failures.len()
+        );
+    }
+    let candidate_attributes = report
+        .candidates
+        .iter()
+        .map(|candidate| (candidate.path.as_str(), candidate.attributes))
+        .collect::<HashMap<_, _>>();
+    let mut failed_paths = HashSet::new();
+    let mut failed_attributes = 0_u64;
+    for failure in &report.failures {
+        if Path::new(&failure.path).is_absolute()
+            || failure.path.trim().is_empty()
+            || failure.stage.trim().is_empty()
+            || failure.error.trim().is_empty()
+        {
+            bail!("report contains an invalid failure record");
+        }
+        if !failed_paths.insert(failure.path.as_str()) {
+            bail!("failure path appears more than once: {}", failure.path);
+        }
+        let attributes = candidate_attributes
+            .get(failure.path.as_str())
+            .ok_or_else(|| eyre!("failure refers to a file outside the candidate set"))?;
+        failed_attributes = failed_attributes
+            .checked_add(*attributes)
+            .ok_or_else(|| eyre!("failed candidate attribute count overflow"))?;
+    }
+    if report
+        .details
+        .iter()
+        .any(|detail| failed_paths.contains(detail.path()))
+    {
+        bail!("failed candidate also contains comparison details");
+    }
+
+    let classified_attributes = report
+        .summary
+        .exact
+        .checked_add(report.summary.custom_only)
+        .and_then(|count| count.checked_add(report.summary.known_order_mismatch))
+        .and_then(|count| count.checked_add(report.summary.extraction_mismatch))
+        .ok_or_else(|| eyre!("summary classification count overflow"))?;
+    if classified_attributes.checked_add(failed_attributes) != Some(report.corpus.attributes) {
+        bail!("summary classifications and failed files do not account for all corpus attributes");
+    }
+    Ok(())
+}
+
+fn validate_fingerprint(expected: &str, actual: &str) -> Result<()> {
+    validate_sha256("expected", expected)?;
+    validate_sha256("reported", actual)?;
+    if actual != expected {
+        bail!("corpus fingerprint mismatch: expected {expected}, found {actual}");
+    }
+    Ok(())
+}
+
+fn validate_sha256(label: &str, value: &str) -> Result<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("{label} fingerprint is not a lowercase SHA-256 digest");
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum FailureReason {
+    Setup,
+    RepositoryUnavailable,
+    InvocationFailed,
+    InvalidReport,
+    KnownOrderMismatch,
+    ExtractionMismatch,
+    HarnessFailure,
+}
+
+impl FailureReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Setup => "setup",
+            Self::RepositoryUnavailable => "repository unavailable",
+            Self::InvocationFailed => "invocation failed",
+            Self::InvalidReport => "invalid report",
+            Self::KnownOrderMismatch => "known-order mismatch",
+            Self::ExtractionMismatch => "extraction mismatch",
+            Self::HarnessFailure => "harness failure",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum CorpusStatus {
+    Passed,
+    Failed,
+}
+
+impl fmt::Display for CorpusStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Passed => formatter.write_str("passed"),
+            Self::Failed => formatter.write_str("failed"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CorpusRunResult {
+    name: &'static str,
+    repository: &'static str,
+    revision: &'static str,
+    status: CorpusStatus,
+    expected: ExpectedCounts,
+    actual: Option<ActualCounts>,
+    reasons: Vec<FailureReason>,
+}
+
+impl CorpusRunResult {
+    fn failed(spec: CorpusSpec, reason: FailureReason) -> Self {
+        Self {
+            name: spec.name.as_str(),
+            repository: spec.repository,
+            revision: spec.revision,
+            status: CorpusStatus::Failed,
+            expected: ExpectedCounts::from(spec.expected),
+            actual: None,
+            reasons: vec![reason],
+        }
+    }
+
+    fn from_report(spec: CorpusSpec, report: &NodeReport) -> Self {
+        let mut reasons = Vec::new();
+        if report.summary.known_order_mismatch > 0 {
+            reasons.push(FailureReason::KnownOrderMismatch);
+        }
+        if report.summary.extraction_mismatch > 0 {
+            reasons.push(FailureReason::ExtractionMismatch);
+        }
+        if report.summary.failures > 0 {
+            reasons.push(FailureReason::HarnessFailure);
+        }
+
+        Self {
+            name: spec.name.as_str(),
+            repository: spec.repository,
+            revision: spec.revision,
+            status: if reasons.is_empty() {
+                CorpusStatus::Passed
+            } else {
+                CorpusStatus::Failed
+            },
+            expected: ExpectedCounts::from(spec.expected),
+            actual: Some(ActualCounts {
+                files: report.corpus.files,
+                attributes: report.corpus.attributes,
+                fingerprint: report.corpus.fingerprint.clone(),
+                summary: report.summary,
+            }),
+            reasons,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExpectedCounts {
+    files: u64,
+    attributes: u64,
+    fingerprint: &'static str,
+}
+
+impl From<ExpectedCorpus> for ExpectedCounts {
+    fn from(expected: ExpectedCorpus) -> Self {
+        Self {
+            files: expected.files,
+            attributes: expected.attributes,
+            fingerprint: expected.fingerprint,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ActualCounts {
+    files: u64,
+    attributes: u64,
+    fingerprint: String,
+    summary: ReportSummary,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum AggregateStatus {
+    Passed,
+    Failed,
+}
+
+impl fmt::Display for AggregateStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Passed => formatter.write_str("passed"),
+            Self::Failed => formatter.write_str("failed"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ComparisonSummary {
+    schema_version: u32,
+    status: AggregateStatus,
+    corpora: Vec<CorpusRunResult>,
+}
+
+impl ComparisonSummary {
+    fn new(corpora: Vec<CorpusRunResult>) -> Self {
+        let status = if corpora
+            .iter()
+            .all(|corpus| corpus.status == CorpusStatus::Passed)
+        {
+            AggregateStatus::Passed
+        } else {
+            AggregateStatus::Failed
+        };
+        Self {
+            schema_version: REPORT_SCHEMA_VERSION,
+            status,
+            corpora,
+        }
+    }
+
+    fn markdown(&self) -> String {
+        let mut markdown = format!(
+            "# Tailwind comparison\n\nOverall status: **{}**\n\n| Corpus | Revision | Files | Attributes | Exact | Custom only | Known-order mismatch | Extraction mismatch | Failures | Status | Reason |\n| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |\n",
+            self.status
+        );
+        for corpus in &self.corpora {
+            let actual = corpus.actual.as_ref();
+            let files = actual
+                .map(|actual| actual.files.to_string())
+                .unwrap_or_else(|| "—".to_string());
+            let attributes = actual
+                .map(|actual| actual.attributes.to_string())
+                .unwrap_or_else(|| "—".to_string());
+            let metric = |select: fn(&ReportSummary) -> u64| {
+                actual
+                    .map(|actual| select(&actual.summary).to_string())
+                    .unwrap_or_else(|| "—".to_string())
+            };
+            let reasons = if corpus.reasons.is_empty() {
+                "—".to_string()
+            } else {
+                corpus
+                    .reasons
+                    .iter()
+                    .map(|reason| reason.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+            markdown.push_str(&format!(
+                "| {} | `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} |\n",
+                corpus.name,
+                corpus.revision,
+                files,
+                attributes,
+                metric(|summary| summary.exact),
+                metric(|summary| summary.custom_only),
+                metric(|summary| summary.known_order_mismatch),
+                metric(|summary| summary.extraction_mismatch),
+                metric(|summary| summary.failures),
+                corpus.status,
+                reasons
+            ));
+        }
+        markdown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FINGERPRINT: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn empty_selection_uses_every_corpus_in_canonical_order() {
+        let selected = select_corpora(&[]);
+
+        assert_eq!(
+            selected.iter().map(|spec| spec.name).collect::<Vec<_>>(),
+            vec![
+                CorpusName::ShadcnUi,
+                CorpusName::ShadcnSvelte,
+                CorpusName::Astrowind
+            ]
+        );
+    }
+
+    #[test]
+    fn explicit_selection_is_deduplicated_and_uses_canonical_order() {
+        let selected = select_corpora(&[
+            CorpusName::Astrowind,
+            CorpusName::ShadcnUi,
+            CorpusName::Astrowind,
+        ]);
+
+        assert_eq!(
+            selected.iter().map(|spec| spec.name).collect::<Vec<_>>(),
+            vec![CorpusName::ShadcnUi, CorpusName::Astrowind]
+        );
+    }
+
+    #[test]
+    fn exact_revision_validation_rejects_abbreviated_and_different_revisions() {
+        let revision = CORPORA[0].revision;
+
+        assert!(validate_exact_revision(revision, revision).is_ok());
+        assert!(validate_exact_revision(revision, &revision[..12]).is_err());
+        assert!(
+            validate_exact_revision(revision, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").is_err()
+        );
+    }
+
+    #[test]
+    fn fingerprint_validation_requires_the_exact_expected_value() {
+        assert!(validate_fingerprint(FINGERPRINT, FINGERPRINT).is_ok());
+        assert!(
+            validate_fingerprint(
+                FINGERPRINT,
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            )
+            .is_err()
+        );
+        assert!(validate_fingerprint("not-a-fingerprint", FINGERPRINT).is_err());
+    }
+
+    #[test]
+    fn custom_only_does_not_fail_aggregate_status() {
+        let report = report_with_summary(ReportSummary {
+            prettier_changed: 1,
+            rustywind_changed: 1,
+            exact: 0,
+            custom_only: 1,
+            known_order_mismatch: 0,
+            extraction_mismatch: 0,
+            failures: 0,
+        });
+        let result = CorpusRunResult::from_report(test_spec(), &report);
+
+        assert_eq!(result.status, CorpusStatus::Passed);
+        assert_eq!(
+            ComparisonSummary::new(vec![result]).status,
+            AggregateStatus::Passed
+        );
+    }
+
+    #[test]
+    fn any_actionable_mismatch_fails_aggregate_status() {
+        for summary in [
+            ReportSummary {
+                prettier_changed: 1,
+                rustywind_changed: 1,
+                exact: 0,
+                custom_only: 0,
+                known_order_mismatch: 1,
+                extraction_mismatch: 0,
+                failures: 0,
+            },
+            ReportSummary {
+                prettier_changed: 1,
+                rustywind_changed: 1,
+                exact: 0,
+                custom_only: 0,
+                known_order_mismatch: 0,
+                extraction_mismatch: 1,
+                failures: 0,
+            },
+            ReportSummary {
+                prettier_changed: 0,
+                rustywind_changed: 0,
+                exact: 0,
+                custom_only: 0,
+                known_order_mismatch: 0,
+                extraction_mismatch: 0,
+                failures: 1,
+            },
+        ] {
+            let result = CorpusRunResult::from_report(test_spec(), &report_with_summary(summary));
+            assert_eq!(
+                ComparisonSummary::new(vec![result]).status,
+                AggregateStatus::Failed
+            );
+        }
+    }
+
+    #[test]
+    fn detail_classifications_must_match_summary_counts() {
+        let mut report = report_with_summary(ReportSummary {
+            prettier_changed: 1,
+            rustywind_changed: 1,
+            exact: 1,
+            custom_only: 0,
+            known_order_mismatch: 0,
+            extraction_mismatch: 0,
+            failures: 0,
+        });
+        report.details.push(ComparisonDetail::KnownOrder {
+            path: "src/file.tsx".to_string(),
+            attribute: 0,
+            original: vec!["px-2".to_string(), "flex".to_string()],
+            prettier: vec!["flex".to_string(), "px-2".to_string()],
+            rustywind: vec!["px-2".to_string(), "flex".to_string()],
+            prettier_unknown: Vec::new(),
+        });
+
+        assert!(validate_details(&report).is_err());
+        report.summary.exact = 0;
+        report.summary.known_order_mismatch = 1;
+        assert!(validate_details(&report).is_ok());
+    }
+
+    #[test]
+    fn deserializes_camel_case_detail_fields() {
+        let detail = serde_json::from_str::<ComparisonDetail>(
+            r#"{
+                "kind": "custom-only",
+                "path": "src/file.tsx",
+                "attribute": 0,
+                "original": ["brand-card", "flex"],
+                "prettier": ["brand-card", "flex"],
+                "rustywind": ["flex", "brand-card"],
+                "prettierUnknown": ["brand-card"]
+            }"#,
+        )
+        .unwrap();
+
+        assert!(matches!(detail, ComparisonDetail::CustomOnly { .. }));
+    }
+
+    fn test_spec() -> CorpusSpec {
+        CorpusSpec::new(
+            CorpusName::ShadcnUi,
+            "example/repository",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "src",
+            CorpusKind::Tsx,
+            1,
+            ExpectedCorpus {
+                files: 1,
+                attributes: 1,
+                fingerprint: FINGERPRINT,
+            },
+        )
+    }
+
+    fn report_with_summary(summary: ReportSummary) -> NodeReport {
+        NodeReport {
+            schema_version: REPORT_SCHEMA_VERSION,
+            corpus: ReportCorpus {
+                name: "shadcn-ui".to_string(),
+                revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+                scope: "src".to_string(),
+                kind: "tsx".to_string(),
+                limit: 1,
+                files: 1,
+                attributes: 1,
+                fingerprint: FINGERPRINT.to_string(),
+            },
+            versions: ToolVersions {
+                prettier: "3.0.0".to_string(),
+                prettier_plugin_tailwindcss: "0.7.0".to_string(),
+                tailwindcss: "4.0.0".to_string(),
+                prettier_plugin_astro: "0.14.0".to_string(),
+                prettier_plugin_svelte: "3.0.0".to_string(),
+            },
+            summary,
+            candidates: vec![Candidate {
+                path: "src/file.tsx".to_string(),
+                attributes: 1,
+            }],
+            details: Vec::new(),
+            failures: Vec::new(),
+        }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,8 @@ use color_eyre::Result;
 use semver::Version;
 use std::str::FromStr;
 
+use commands::compare::CorpusName;
+
 #[derive(Parser)]
 #[command(name = "xtask")]
 #[command(about = "RustyWind automation tasks", long_about = None)]
@@ -16,6 +18,11 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Tailwind compatibility comparison commands
+    Compare {
+        #[command(subcommand)]
+        subcommand: CompareCommand,
+    },
     /// Fuzz testing commands
     Fuzz {
         #[command(subcommand)]
@@ -25,6 +32,20 @@ enum Command {
     Npm {
         #[command(subcommand)]
         subcommand: NpmCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum CompareCommand {
+    /// Compare RustyWind against pinned real-world corpora
+    Run {
+        /// Corpus to compare; repeat to select multiple corpora
+        #[arg(long, value_enum)]
+        corpus: Vec<CorpusName>,
+
+        /// Use only existing repositories and npm's local cache
+        #[arg(long)]
+        offline: bool,
     },
 }
 
@@ -118,6 +139,9 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
+        Command::Compare { subcommand } => match subcommand {
+            CompareCommand::Run { corpus, offline } => commands::compare::run(&corpus, offline),
+        },
         Command::Fuzz { subcommand } => match subcommand {
             FuzzCommand::Setup => commands::setup::run(),
             FuzzCommand::Run {


### PR DESCRIPTION
Compare RustyWind with pinned real-world TSX, Svelte, and Astro corpora through xtask. Lock formatter inputs and corpus fingerprints so large parser changes can be checked reproducibly.

Treat shared-order and extraction differences as failures while reporting custom utilities separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `xtask compare` command to compare RustyWind output against pinned Tailwind snapshots.
  - Supports running selected corpora or all, including offline execution.
  - Produces validated JSON and Markdown comparison reports.
  - Added `just compare-tailwind` with argument forwarding.

- **Documentation**
  - Expanded `xtask` documentation with the compare workflow and prerequisites.

- **Tests**
  - Added Tailwind comparison harness, utilities, and automated coverage for parsing, token handling, classification, ordering, fingerprints, and report validation.
  - Added tests for error-message path scrubbing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->