### PR TITLE
Add real-world repo comparisons to Rustywind tests

### DIFF
--- a/rustywind-core/src/variant_order.rs
+++ b/rustywind-core/src/variant_order.rs
@@ -291,8 +291,20 @@ impl DefaultContainerBreakpoint {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ContainerQueryDirection {
+    Maximum,
+    Minimum,
+}
+
 #[derive(Debug, Clone, Copy)]
 enum ContainerBreakpoint<'a> {
+    Resolved(ResolvedContainerBreakpoint<'a>),
+    Named(&'a str),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ResolvedContainerBreakpoint<'a> {
     Default(DefaultContainerBreakpoint),
     Arbitrary(&'a str),
 }
@@ -303,13 +315,36 @@ impl<'a> ContainerBreakpoint<'a> {
             .strip_prefix('[')
             .and_then(|value| value.strip_suffix(']'))
         {
-            return (!value.trim().is_empty() && !value.contains("var("))
-                .then_some(Self::Arbitrary(value));
+            return (!value.trim().is_empty() && !value.contains("var(")).then_some(
+                Self::Resolved(ResolvedContainerBreakpoint::Arbitrary(value)),
+            );
         }
 
-        DefaultContainerBreakpoint::parse(value).map(Self::Default)
+        DefaultContainerBreakpoint::parse(value)
+            .map(ResolvedContainerBreakpoint::Default)
+            .map(Self::Resolved)
+            .or_else(|| is_named_variant_value(value).then_some(Self::Named(value)))
     }
 
+    fn cmp_for_query(self, other: Self, direction: ContainerQueryDirection) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+
+        match (self, other) {
+            (Self::Named(a), Self::Named(b)) => a.cmp(b),
+            (Self::Named(_), _) => Ordering::Greater,
+            (_, Self::Named(_)) => Ordering::Less,
+            (Self::Resolved(a), Self::Resolved(b)) => {
+                let ordering = compare_container_breakpoint_values(a.css_value(), b.css_value());
+                match direction {
+                    ContainerQueryDirection::Maximum => ordering.reverse(),
+                    ContainerQueryDirection::Minimum => ordering,
+                }
+            }
+        }
+    }
+}
+
+impl<'a> ResolvedContainerBreakpoint<'a> {
     fn css_value(self) -> &'a str {
         match self {
             Self::Default(breakpoint) => breakpoint.css_value(),
@@ -320,28 +355,18 @@ impl<'a> ContainerBreakpoint<'a> {
 
 impl PartialEq for ContainerBreakpoint<'_> {
     fn eq(&self, other: &Self) -> bool {
-        compare_container_breakpoint_values(self.css_value(), other.css_value()).is_eq()
+        self.cmp_for_query(*other, ContainerQueryDirection::Minimum)
+            .is_eq()
     }
 }
 
 impl Eq for ContainerBreakpoint<'_> {}
 
-impl Ord for ContainerBreakpoint<'_> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        compare_container_breakpoint_values(self.css_value(), other.css_value())
-    }
-}
-
-impl PartialOrd for ContainerBreakpoint<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum ContainerQueryDirection {
-    Maximum,
-    Minimum,
+fn is_named_variant_value(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'%' | b'-'))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -378,10 +403,9 @@ impl<'a> ContainerQuery<'a> {
 impl Ord for ContainerQuery<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match self.direction.cmp(&other.direction) {
-            std::cmp::Ordering::Equal => match self.direction {
-                ContainerQueryDirection::Minimum => self.breakpoint.cmp(&other.breakpoint),
-                ContainerQueryDirection::Maximum => other.breakpoint.cmp(&self.breakpoint),
-            },
+            std::cmp::Ordering::Equal => self
+                .breakpoint
+                .cmp_for_query(other.breakpoint, self.direction),
             ordering => ordering,
         }
     }
@@ -423,10 +447,27 @@ fn split_container_query_name(variant: &str) -> Option<&str> {
     }
 
     match separator {
-        Some(index) if index + 1 < variant.len() => Some(&variant[..index]),
-        Some(_) => None,
+        Some(index) => is_container_query_name(&variant[index + 1..]).then_some(&variant[..index]),
         None => Some(variant),
     }
+}
+
+fn is_container_query_name(value: &str) -> bool {
+    if is_named_variant_value(value) {
+        return true;
+    }
+
+    if let Some(value) = value
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    {
+        return !value.trim().is_empty();
+    }
+
+    value
+        .strip_prefix('(')
+        .and_then(|value| value.strip_suffix(')'))
+        .is_some_and(|value| value.starts_with("--") && value.len() > 2)
 }
 
 fn compare_container_breakpoint_values(a: &str, b: &str) -> std::cmp::Ordering {
@@ -825,6 +866,11 @@ mod tests {
         assert_eq!(get_variant_index("@3xs"), Some(77));
         assert_eq!(get_variant_index("@min-md/sidebar"), Some(77));
 
+        // test named custom container query variants
+        assert_eq!(get_variant_index("@max-tablet"), Some(76));
+        assert_eq!(get_variant_index("@tablet"), Some(77));
+        assert_eq!(get_variant_index("@min-tablet/sidebar"), Some(77));
+
         // test orientation (portrait before landscape)
         assert_eq!(get_variant_index("portrait"), Some(78));
         assert_eq!(get_variant_index("landscape"), Some(79));
@@ -918,6 +964,35 @@ mod tests {
     }
 
     #[test]
+    fn test_named_custom_container_query_breakpoints_are_known() {
+        for (variant, expected_index) in [
+            ("@tablet", 77),
+            ("@min-tablet", 77),
+            ("@max-tablet", 76),
+            ("@tablet/sidebar", 77),
+            ("@min-tablet/sidebar", 77),
+            ("@max-tablet/sidebar", 76),
+        ] {
+            assert_eq!(
+                get_variant_index(variant),
+                Some(expected_index),
+                "{variant}"
+            );
+            assert_eq!(
+                calculate_variant_order(&[variant]) & ARBITRARY_VARIANT_BIT,
+                0,
+                "{variant}"
+            );
+        }
+
+        assert_eq!(
+            VariantInfo::parse("@tablet/sidebar")
+                .cmp_variants(&VariantInfo::parse("@min-tablet/content")),
+            std::cmp::Ordering::Equal
+        );
+    }
+
+    #[test]
     fn test_arbitrary_container_query_breakpoints_follow_size_order() {
         let minimum =
             ["@[20rem]", "@sm", "@md", "@[30rem]", "@min-[40rem]"].map(VariantInfo::parse);
@@ -965,12 +1040,12 @@ mod tests {
     #[test]
     fn test_invalid_container_queries_remain_unknown() {
         for variant in [
-            "@tablet",
-            "@min-tablet",
-            "@max-tablet",
             "@[]",
             "@min-[var(--width)]",
+            "@max-tablet?",
             "@md/",
+            "@tablet/[ ]",
+            "@tablet/side:bar",
             "@md/sidebar/nested",
         ] {
             assert_eq!(get_variant_index(variant), None, "{variant}");

--- a/rustywind-core/tests/integration_tests.rs
+++ b/rustywind-core/tests/integration_tests.rs
@@ -745,27 +745,26 @@ fn test_container_names_do_not_precede_same_breakpoint_tiebreakers() {
 }
 
 #[test]
-fn test_custom_container_query_names_remain_unknown() {
+fn test_custom_container_query_names_use_container_variant_buckets() {
     let sorter = HybridSorter::new();
-    let classes = vec!["@tablet:m-4", "@min-tablet:m-4", "print:m-4", "@7xl:m-4"];
-    let sorted = sorter.sort_classes(&classes);
-    let print_pos = sorted
-        .iter()
-        .position(|class| *class == "print:m-4")
-        .unwrap();
-    let known_container_pos = sorted
-        .iter()
-        .position(|class| *class == "@7xl:m-4")
-        .unwrap();
+    let classes = vec![
+        "@tablet:m-4",
+        "print:m-4",
+        "@min-tablet:m-4",
+        "@max-tablet:m-4",
+        "@7xl:m-4",
+    ];
 
-    assert!(known_container_pos < print_pos);
-    for class in ["@tablet:m-4", "@min-tablet:m-4"] {
-        let custom_pos = sorted
-            .iter()
-            .position(|candidate| *candidate == class)
-            .unwrap();
-        assert!(print_pos < custom_pos, "{class}");
-    }
+    assert_eq!(
+        sorter.sort_classes(&classes),
+        vec![
+            "@max-tablet:m-4",
+            "@7xl:m-4",
+            "@min-tablet:m-4",
+            "@tablet:m-4",
+            "print:m-4",
+        ]
+    );
 }
 
 #[test]

--- a/tests/tailwind-compare/lib.mjs
+++ b/tests/tailwind-compare/lib.mjs
@@ -11,7 +11,7 @@ export const kinds = Object.freeze({
 });
 
 export function isStaticCandidate(value) {
-  return !/[{}]/u.test(value) && !value.includes("<%") && !value.includes("<?");
+  return !value.includes("<%") && !value.includes("<?");
 }
 
 function walk(root, visit) {
@@ -259,9 +259,8 @@ export function classifyDifference(comparison, known) {
   } = comparison;
   if (
     !sameMultiset(original, scrambled) ||
-    !sameMultiset(original, prettierOriginal) ||
-    !sameMultiset(scrambled, prettierScrambled) ||
-    !sameMultiset(scrambled, rustywind)
+    !sameMultiset(prettierOriginal, prettierScrambled) ||
+    !sameMultiset(prettierOriginal, rustywind)
   ) {
     return "token-multiset";
   }

--- a/tests/tailwind-compare/lib.mjs
+++ b/tests/tailwind-compare/lib.mjs
@@ -76,9 +76,33 @@ function findSvelteAttributes(source) {
   return attributes;
 }
 
+function stringIndicesByUtf8Offset(source, byteOffsets) {
+  const indices = new Map();
+  const pending = [...new Set(byteOffsets)].sort((left, right) => left - right);
+  let byteOffset = 0;
+  let stringIndex = 0;
+
+  for (const target of pending) {
+    while (byteOffset < target) {
+      const codePoint = source.codePointAt(stringIndex);
+      if (codePoint === undefined) {
+        throw new Error(`Astro source position ${target} is outside the source`);
+      }
+      byteOffset += Buffer.byteLength(String.fromCodePoint(codePoint), "utf8");
+      stringIndex += codePoint > 0xffff ? 2 : 1;
+    }
+    if (byteOffset !== target) {
+      throw new Error(`Astro source position ${target} splits a UTF-8 character`);
+    }
+    indices.set(target, stringIndex);
+  }
+
+  return indices;
+}
+
 function findAstroAttributes(source) {
   const { ast } = parseAstro(source, { position: true });
-  const attributes = [];
+  const candidates = [];
   walk(ast, (node) => {
     if (
       node.type !== "attribute" ||
@@ -91,17 +115,35 @@ function findAstroAttributes(source) {
     if ((quote !== '"' && quote !== "'") || node.raw.at(-1) !== quote) {
       return;
     }
-    const rawStart = source.indexOf(
-      node.raw,
-      node.position.start.offset + node.name.length,
-    );
-    if (rawStart === -1) return;
-    attributes.push({
-      end: rawStart + node.raw.length - 1,
-      start: rawStart + 1,
-    });
+    const offset = node.position?.start?.offset;
+    if (!Number.isSafeInteger(offset) || offset < 0) {
+      throw new Error(`Astro ${node.name} attribute has an invalid position`);
+    }
+    candidates.push({ name: node.name, offset, raw: node.raw });
   });
-  return attributes;
+
+  const stringIndices = stringIndicesByUtf8Offset(
+    source,
+    candidates.map(({ offset }) => offset),
+  );
+  return candidates.map(({ name, offset, raw }) => {
+    const attributeStart = stringIndices.get(offset);
+    if (attributeStart === undefined) {
+      throw new Error(`Could not resolve Astro ${name} attribute position`);
+    }
+    const assignmentStart = attributeStart + name.length;
+    const rawStart = source.indexOf(raw, assignmentStart);
+    if (
+      rawStart === -1 ||
+      !/^\s*=\s*$/u.test(source.slice(assignmentStart, rawStart))
+    ) {
+      throw new Error(`Could not resolve Astro ${name} attribute value`);
+    }
+    return {
+      end: rawStart + raw.length - 1,
+      start: rawStart + 1,
+    };
+  });
 }
 
 function findStaticAttributes(source, kind) {

--- a/tests/tailwind-compare/test/lib.test.mjs
+++ b/tests/tailwind-compare/test/lib.test.mjs
@@ -27,6 +27,7 @@ test("extracts only static quoted class attributes", () => {
   assert.deepEqual(extractAttributes(source, "astro"), [
     "flex p-4",
     "grid gap-2",
+    "before:content-['{']",
   ]);
 });
 
@@ -208,7 +209,7 @@ test("rejects order classification without a result for every token", () => {
   );
 });
 
-test("rejects convergent token removal by both formatters", () => {
+test("compares ordering after matching formatter deduplication", () => {
   assert.equal(
     classifyDifference({
       original: ["rtl:mr-0", "flex", "rtl:mr-0"],
@@ -217,7 +218,7 @@ test("rejects convergent token removal by both formatters", () => {
       prettierScrambled: ["flex", "rtl:mr-0"],
       rustywind: ["flex", "rtl:mr-0"],
     }),
-    "token-multiset",
+    "exact",
   );
 });
 

--- a/tests/tailwind-compare/test/lib.test.mjs
+++ b/tests/tailwind-compare/test/lib.test.mjs
@@ -72,6 +72,25 @@ const sample = '<div class="fake string">';
   }
 });
 
+test("preserves Astro attribute positions after multibyte text", () => {
+  const source = `---
+// →
+---
+<div class="flex p-4"></div>
+<span class="grid gap-2"></span>
+`;
+  const scrambled = scrambleAttributes(source, "astro");
+
+  assert.deepEqual(extractAttributes(source, "astro"), [
+    "flex p-4",
+    "grid gap-2",
+  ]);
+  assert.deepEqual(extractAttributes(scrambled, "astro"), [
+    "p-4 flex",
+    "gap-2 grid",
+  ]);
+});
+
 test("splits whitespace outside arbitrary-value brackets", () => {
   const value = String.raw`sm:hover:flex [grid-template-columns:1fr_2fr] content-['hello world'] [--value:'a \' b'] p-4`;
 

--- a/xtask/src/commands/compare.rs
+++ b/xtask/src/commands/compare.rs
@@ -21,17 +21,25 @@ const MINIMUM_NODE_VERSION: &str = ">=20.19.0";
 pub(crate) enum CorpusName {
     #[value(name = "shadcn-ui")]
     ShadcnUi,
+    Tremor,
     #[value(name = "shadcn-svelte")]
     ShadcnSvelte,
+    #[value(name = "flowbite-svelte")]
+    FlowbiteSvelte,
     Astrowind,
+    #[value(name = "astro-paper")]
+    AstroPaper,
 }
 
 impl CorpusName {
     fn as_str(self) -> &'static str {
         match self {
             Self::ShadcnUi => "shadcn-ui",
+            Self::Tremor => "tremor",
             Self::ShadcnSvelte => "shadcn-svelte",
+            Self::FlowbiteSvelte => "flowbite-svelte",
             Self::Astrowind => "astrowind",
+            Self::AstroPaper => "astro-paper",
         }
     }
 }
@@ -104,7 +112,7 @@ impl CorpusSpec {
 }
 
 // update these fingerprints after intentionally refreshing the pinned corpus reports
-const CORPORA: [CorpusSpec; 3] = [
+const CORPORA: &[CorpusSpec] = &[
     CorpusSpec::new(
         CorpusName::ShadcnUi,
         "shadcn-ui/ui",
@@ -119,6 +127,19 @@ const CORPORA: [CorpusSpec; 3] = [
         },
     ),
     CorpusSpec::new(
+        CorpusName::Tremor,
+        "tremorlabs/tremor",
+        "ca4d588f47820ff3d514d37fa4ee08a4222dec11",
+        "src",
+        CorpusKind::Tsx,
+        40,
+        ExpectedCorpus {
+            files: 40,
+            attributes: 560,
+            fingerprint: "2b1c2815ba2f41173d6a2c5b3f95e790671ba56a1e699949c27cc437ee85f13e",
+        },
+    ),
+    CorpusSpec::new(
         CorpusName::ShadcnSvelte,
         "huntabyte/shadcn-svelte",
         "efcf8a4ef2c6a3a21ee2fd4db905519f8d4c8e63",
@@ -127,8 +148,21 @@ const CORPORA: [CorpusSpec; 3] = [
         40,
         ExpectedCorpus {
             files: 40,
-            attributes: 717,
-            fingerprint: "2b1e23a82fff982fe3f270a2cefaffeac3290c2fc640a656dd77a176bf13d80e",
+            attributes: 713,
+            fingerprint: "15e18692dc1bd3651867a52b12ed8f60cd1527c922b0258c15c1afef0fb79200",
+        },
+    ),
+    CorpusSpec::new(
+        CorpusName::FlowbiteSvelte,
+        "themesberg/flowbite-svelte",
+        "85f20a048ec51598e2be099bd57b5f555fe7a5b4",
+        "src/routes",
+        CorpusKind::Svelte,
+        40,
+        ExpectedCorpus {
+            files: 40,
+            attributes: 1382,
+            fingerprint: "d8d0a5b916a56f75a0028a35470e00a7ae95fefb3854b0c42bbc683c192f1ef4",
         },
     ),
     CorpusSpec::new(
@@ -139,9 +173,22 @@ const CORPORA: [CorpusSpec; 3] = [
         CorpusKind::Astro,
         53,
         ExpectedCorpus {
-            files: 53,
-            attributes: 379,
-            fingerprint: "7045db395ba1d01792b2731e78c94744745a9e6da56a6920fdd71efde752ac3e",
+            files: 52,
+            attributes: 362,
+            fingerprint: "5b8ae1fae9cee54b8b2748f9d05f89c3cd34fa225c28e3d658af4c452ccfe172",
+        },
+    ),
+    CorpusSpec::new(
+        CorpusName::AstroPaper,
+        "satnaing/astro-paper",
+        "4fe3aca0e09ed8404ec2e716ac4f3b57ccc252eb",
+        "src",
+        CorpusKind::Astro,
+        40,
+        ExpectedCorpus {
+            files: 20,
+            attributes: 103,
+            fingerprint: "2448e76486173bf89f516755cd0733c06f3fe13548ce88d53c86fbe8df7ed37b",
         },
     ),
 ];
@@ -870,6 +917,53 @@ fn validate_candidates(report: &NodeReport) -> Result<()> {
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+struct ComparisonTokens<'a> {
+    original: &'a [String],
+    scrambled: &'a [String],
+    prettier_original: &'a [String],
+    prettier_scrambled: &'a [String],
+    rustywind: &'a [String],
+}
+
+impl<'a> ComparisonTokens<'a> {
+    fn new(
+        original: &'a [String],
+        scrambled: &'a [String],
+        prettier_original: &'a [String],
+        prettier_scrambled: &'a [String],
+        rustywind: &'a [String],
+    ) -> Self {
+        Self {
+            original,
+            scrambled,
+            prettier_original,
+            prettier_scrambled,
+            rustywind,
+        }
+    }
+
+    fn contains_invalid_token(self) -> bool {
+        [
+            self.original,
+            self.scrambled,
+            self.prettier_original,
+            self.prettier_scrambled,
+            self.rustywind,
+        ]
+        .into_iter()
+        .flatten()
+        .any(|token| token.contains('\0'))
+    }
+
+    fn multisets_match(self) -> bool {
+        same_token_multiset(self.original, self.scrambled)
+            && [self.prettier_scrambled, self.rustywind]
+                .into_iter()
+                .all(|tokens| same_token_multiset(self.prettier_original, tokens))
+    }
+}
+
 fn validate_details(report: &NodeReport) -> Result<()> {
     let candidate_attributes = report
         .candidates
@@ -929,24 +1023,21 @@ fn validate_details(report: &NodeReport) -> Result<()> {
                 rustywind,
                 ..
             } => {
+                let tokens = ComparisonTokens::new(
+                    original,
+                    scrambled,
+                    prettier_original,
+                    prettier_scrambled,
+                    rustywind,
+                );
                 validate_attribute_detail(
                     path,
                     *attribute,
                     candidate_attributes,
-                    original,
-                    scrambled,
-                    prettier_original,
-                    prettier_scrambled,
-                    rustywind,
+                    tokens,
                     &mut attribute_details,
                 )?;
-                if comparison_multisets_match(
-                    original,
-                    scrambled,
-                    prettier_original,
-                    prettier_scrambled,
-                    rustywind,
-                ) {
+                if tokens.multisets_match() {
                     bail!("token-multiset detail does not describe a mismatch");
                 }
                 extraction = extraction
@@ -962,24 +1053,21 @@ fn validate_details(report: &NodeReport) -> Result<()> {
                 rustywind,
                 ..
             } => {
+                let tokens = ComparisonTokens::new(
+                    original,
+                    scrambled,
+                    prettier_original,
+                    prettier_scrambled,
+                    rustywind,
+                );
                 validate_attribute_detail(
                     path,
                     *attribute,
                     candidate_attributes,
-                    original,
-                    scrambled,
-                    prettier_original,
-                    prettier_scrambled,
-                    rustywind,
+                    tokens,
                     &mut attribute_details,
                 )?;
-                validate_ordering_detail(
-                    original,
-                    scrambled,
-                    prettier_original,
-                    prettier_scrambled,
-                    rustywind,
-                )?;
+                validate_ordering_detail(tokens)?;
                 if prettier_original == prettier_scrambled {
                     bail!("prettier-nonconvergent detail contains convergent output");
                 }
@@ -997,24 +1085,21 @@ fn validate_details(report: &NodeReport) -> Result<()> {
                 prettier_unknown,
                 ..
             } => {
+                let tokens = ComparisonTokens::new(
+                    original,
+                    scrambled,
+                    prettier_original,
+                    prettier_scrambled,
+                    rustywind,
+                );
                 validate_attribute_detail(
                     path,
                     *attribute,
                     candidate_attributes,
-                    original,
-                    scrambled,
-                    prettier_original,
-                    prettier_scrambled,
-                    rustywind,
+                    tokens,
                     &mut attribute_details,
                 )?;
-                validate_convergent_mismatch(
-                    original,
-                    scrambled,
-                    prettier_original,
-                    prettier_scrambled,
-                    rustywind,
-                )?;
+                validate_convergent_mismatch(tokens)?;
                 validate_unknown_tokens(prettier_unknown, rustywind)?;
                 custom_only = custom_only
                     .checked_add(1)
@@ -1030,24 +1115,21 @@ fn validate_details(report: &NodeReport) -> Result<()> {
                 prettier_unknown,
                 ..
             } => {
+                let tokens = ComparisonTokens::new(
+                    original,
+                    scrambled,
+                    prettier_original,
+                    prettier_scrambled,
+                    rustywind,
+                );
                 validate_attribute_detail(
                     path,
                     *attribute,
                     candidate_attributes,
-                    original,
-                    scrambled,
-                    prettier_original,
-                    prettier_scrambled,
-                    rustywind,
+                    tokens,
                     &mut attribute_details,
                 )?;
-                validate_convergent_mismatch(
-                    original,
-                    scrambled,
-                    prettier_original,
-                    prettier_scrambled,
-                    rustywind,
-                )?;
+                validate_convergent_mismatch(tokens)?;
                 validate_unknown_tokens(prettier_unknown, rustywind)?;
                 known_order = known_order
                     .checked_add(1)
@@ -1076,22 +1158,13 @@ fn validate_attribute_detail(
     path: &str,
     attribute: u64,
     candidate_attributes: u64,
-    original: &[String],
-    scrambled: &[String],
-    prettier_original: &[String],
-    prettier_scrambled: &[String],
-    rustywind: &[String],
+    tokens: ComparisonTokens<'_>,
     seen: &mut HashSet<(String, u64)>,
 ) -> Result<()> {
     if attribute >= candidate_attributes {
         bail!("detail attribute index is outside its candidate");
     }
-    if original.iter().any(|token| token.contains('\0'))
-        || scrambled.iter().any(|token| token.contains('\0'))
-        || prettier_original.iter().any(|token| token.contains('\0'))
-        || prettier_scrambled.iter().any(|token| token.contains('\0'))
-        || rustywind.iter().any(|token| token.contains('\0'))
-    {
+    if tokens.contains_invalid_token() {
         bail!("comparison detail contains an invalid class token");
     }
     if !seen.insert((path.to_string(), attribute)) {
@@ -1100,59 +1173,22 @@ fn validate_attribute_detail(
     Ok(())
 }
 
-fn validate_ordering_detail(
-    original: &[String],
-    scrambled: &[String],
-    prettier_original: &[String],
-    prettier_scrambled: &[String],
-    rustywind: &[String],
-) -> Result<()> {
-    if !comparison_multisets_match(
-        original,
-        scrambled,
-        prettier_original,
-        prettier_scrambled,
-        rustywind,
-    ) {
+fn validate_ordering_detail(tokens: ComparisonTokens<'_>) -> Result<()> {
+    if !tokens.multisets_match() {
         bail!("ordering detail contains a token-multiset mismatch");
     }
     Ok(())
 }
 
-fn validate_convergent_mismatch(
-    original: &[String],
-    scrambled: &[String],
-    prettier_original: &[String],
-    prettier_scrambled: &[String],
-    rustywind: &[String],
-) -> Result<()> {
-    validate_ordering_detail(
-        original,
-        scrambled,
-        prettier_original,
-        prettier_scrambled,
-        rustywind,
-    )?;
-    if prettier_original != prettier_scrambled {
+fn validate_convergent_mismatch(tokens: ComparisonTokens<'_>) -> Result<()> {
+    validate_ordering_detail(tokens)?;
+    if tokens.prettier_original != tokens.prettier_scrambled {
         bail!("ordering mismatch uses nonconvergent Prettier output");
     }
-    if prettier_scrambled == rustywind {
+    if tokens.prettier_scrambled == tokens.rustywind {
         bail!("ordering mismatch does not describe a mismatch");
     }
     Ok(())
-}
-
-fn comparison_multisets_match(
-    original: &[String],
-    scrambled: &[String],
-    prettier_original: &[String],
-    prettier_scrambled: &[String],
-    rustywind: &[String],
-) -> bool {
-    same_token_multiset(original, scrambled)
-        && [prettier_scrambled, rustywind]
-            .into_iter()
-            .all(|tokens| same_token_multiset(prettier_original, tokens))
 }
 
 fn same_token_multiset(left: &[String], right: &[String]) -> bool {
@@ -1491,8 +1527,11 @@ mod tests {
             selected.iter().map(|spec| spec.name).collect::<Vec<_>>(),
             vec![
                 CorpusName::ShadcnUi,
+                CorpusName::Tremor,
                 CorpusName::ShadcnSvelte,
-                CorpusName::Astrowind
+                CorpusName::FlowbiteSvelte,
+                CorpusName::Astrowind,
+                CorpusName::AstroPaper,
             ]
         );
     }
@@ -1604,9 +1643,10 @@ mod tests {
         ];
         let formatted = vec!["flex".to_string(), "rtl:mr-0".to_string()];
 
-        assert!(comparison_multisets_match(
-            &original, &scrambled, &formatted, &formatted, &formatted,
-        ));
+        assert!(
+            ComparisonTokens::new(&original, &scrambled, &formatted, &formatted, &formatted)
+                .multisets_match()
+        );
     }
 
     #[test]

--- a/xtask/src/commands/compare.rs
+++ b/xtask/src/commands/compare.rs
@@ -207,6 +207,59 @@ struct CompareRunner {
 
 struct RustywindBinary(PathBuf);
 
+#[derive(Clone, Copy)]
+enum RevisionFetchMode {
+    Shallow,
+    Complete,
+}
+
+#[derive(Clone, Copy)]
+struct RevisionFetch<'a> {
+    repository: &'a Path,
+    revision: &'a str,
+}
+
+impl<'a> RevisionFetch<'a> {
+    fn new(repository: &'a Path, revision: &'a str) -> Self {
+        Self {
+            repository,
+            revision,
+        }
+    }
+
+    fn run(self) -> Result<()> {
+        self.run_with(run_checked)
+    }
+
+    fn run_with(self, mut run: impl FnMut(&mut Command, &str) -> Result<()>) -> Result<()> {
+        let mut shallow = self.command(RevisionFetchMode::Shallow);
+        let shallow_error = match run(&mut shallow, "fetch pinned corpus revision shallowly") {
+            Ok(()) => return Ok(()),
+            Err(error) => error,
+        };
+
+        eprintln!("Shallow corpus fetch failed; retrying without a depth limit: {shallow_error:#}");
+        let mut complete = self.command(RevisionFetchMode::Complete);
+        run(
+            &mut complete,
+            "fetch pinned corpus revision without a depth limit",
+        )
+        .wrap_err_with(|| format!("shallow corpus fetch also failed: {shallow_error:#}"))
+    }
+
+    fn command(self, mode: RevisionFetchMode) -> Command {
+        let mut command = Command::new("git");
+        command
+            .current_dir(self.repository)
+            .args(["fetch", "--quiet"]);
+        if matches!(mode, RevisionFetchMode::Shallow) {
+            command.arg("--depth=1");
+        }
+        command.args(["origin", self.revision]);
+        command
+    }
+}
+
 impl RustywindBinary {
     fn build(workspace: &Path, offline: bool) -> Result<Self> {
         let mut build = Command::new("cargo");
@@ -372,15 +425,7 @@ impl CompareRunner {
 
         if !self.offline {
             self.configure_remote(&repository, spec)?;
-            let mut fetch = Command::new("git");
-            fetch.current_dir(&repository).args([
-                "fetch",
-                "--quiet",
-                "--depth=1",
-                "origin",
-                spec.revision,
-            ]);
-            run_checked(&mut fetch, "fetch pinned corpus revision")?;
+            RevisionFetch::new(&repository, spec.revision).run()?;
         }
 
         let mut checkout = Command::new("git");
@@ -962,6 +1007,22 @@ impl<'a> ComparisonTokens<'a> {
                 .into_iter()
                 .all(|tokens| same_token_multiset(self.prettier_original, tokens))
     }
+
+    fn known_token_order_is_preserved(self, unknown: &HashSet<&str>) -> bool {
+        self.prettier_scrambled
+            .iter()
+            .filter(|token| !unknown.contains(token.as_str()))
+            .eq(self
+                .rustywind
+                .iter()
+                .filter(|token| !unknown.contains(token.as_str())))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ExpectedKnownTokenOrder {
+    Preserved,
+    Changed,
 }
 
 fn validate_details(report: &NodeReport) -> Result<()> {
@@ -1100,7 +1161,11 @@ fn validate_details(report: &NodeReport) -> Result<()> {
                     &mut attribute_details,
                 )?;
                 validate_convergent_mismatch(tokens)?;
-                validate_unknown_tokens(prettier_unknown, rustywind)?;
+                validate_known_token_order(
+                    tokens,
+                    prettier_unknown,
+                    ExpectedKnownTokenOrder::Preserved,
+                )?;
                 custom_only = custom_only
                     .checked_add(1)
                     .ok_or_else(|| eyre!("custom-only detail count overflow"))?;
@@ -1130,7 +1195,11 @@ fn validate_details(report: &NodeReport) -> Result<()> {
                     &mut attribute_details,
                 )?;
                 validate_convergent_mismatch(tokens)?;
-                validate_unknown_tokens(prettier_unknown, rustywind)?;
+                validate_known_token_order(
+                    tokens,
+                    prettier_unknown,
+                    ExpectedKnownTokenOrder::Changed,
+                )?;
                 known_order = known_order
                     .checked_add(1)
                     .ok_or_else(|| eyre!("known-order detail count overflow"))?;
@@ -1199,11 +1268,35 @@ fn same_token_multiset(left: &[String], right: &[String]) -> bool {
     left == right
 }
 
-fn validate_unknown_tokens(unknown: &[String], rustywind: &[String]) -> Result<()> {
-    if unknown.iter().any(|token| !rustywind.contains(token)) {
-        bail!("detail unknown token is absent from the RustyWind tokens");
+fn validate_known_token_order(
+    tokens: ComparisonTokens<'_>,
+    unknown: &[String],
+    expected: ExpectedKnownTokenOrder,
+) -> Result<()> {
+    let unknown_set = unknown.iter().map(String::as_str).collect::<HashSet<_>>();
+    if unknown_set.len() != unknown.len() {
+        bail!("detail unknown token list contains duplicates");
     }
-    Ok(())
+    if unknown.iter().any(|token| {
+        !tokens.prettier_scrambled.contains(token) || !tokens.rustywind.contains(token)
+    }) {
+        bail!("detail unknown token is absent from the comparison tokens");
+    }
+
+    match (
+        expected,
+        tokens.known_token_order_is_preserved(&unknown_set),
+    ) {
+        (ExpectedKnownTokenOrder::Preserved, true) | (ExpectedKnownTokenOrder::Changed, false) => {
+            Ok(())
+        }
+        (ExpectedKnownTokenOrder::Preserved, false) => {
+            bail!("custom-only detail changes the order of known Tailwind tokens")
+        }
+        (ExpectedKnownTokenOrder::Changed, true) => {
+            bail!("known-order detail preserves the order of known Tailwind tokens")
+        }
+    }
 }
 
 fn validate_failures(report: &NodeReport) -> Result<()> {
@@ -1504,6 +1597,35 @@ mod tests {
     const FINGERPRINT: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
     #[test]
+    fn revision_fetch_retries_without_a_depth_limit() {
+        let mut attempts = Vec::new();
+
+        RevisionFetch::new(Path::new("/repository"), "abc123")
+            .run_with(|command, _| {
+                attempts.push(
+                    command
+                        .get_args()
+                        .map(|argument| argument.to_string_lossy().into_owned())
+                        .collect::<Vec<_>>(),
+                );
+                if attempts.len() == 1 {
+                    Err(eyre!("shallow fetch rejected"))
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap();
+
+        assert_eq!(
+            attempts,
+            vec![
+                vec!["fetch", "--quiet", "--depth=1", "origin", "abc123"],
+                vec!["fetch", "--quiet", "origin", "abc123"],
+            ]
+        );
+    }
+
+    #[test]
     fn binary_resolution_uses_cargo_reported_executable() {
         let expected = PathBuf::from(
             "/custom-target/aarch64-unknown-linux-gnu/release/rustywind-custom-suffix",
@@ -1746,6 +1868,73 @@ mod tests {
         report.summary.exact = 0;
         report.summary.known_order_mismatch = 1;
         assert!(validate_details(&report).is_ok());
+    }
+
+    #[test]
+    fn custom_only_and_known_order_require_distinct_known_token_orders() {
+        let original = vec!["flex".to_string(), "px-2".to_string()];
+        let scrambled = vec![
+            "brand-card".to_string(),
+            "flex".to_string(),
+            "px-2".to_string(),
+        ];
+        let prettier_original = original.clone();
+        let prettier_scrambled = scrambled.clone();
+        let preserved = vec![
+            "flex".to_string(),
+            "brand-card".to_string(),
+            "px-2".to_string(),
+        ];
+        let changed = vec![
+            "px-2".to_string(),
+            "brand-card".to_string(),
+            "flex".to_string(),
+        ];
+        let unknown = vec!["brand-card".to_string()];
+
+        let preserved_tokens = ComparisonTokens::new(
+            &original,
+            &scrambled,
+            &prettier_original,
+            &prettier_scrambled,
+            &preserved,
+        );
+        assert!(
+            validate_known_token_order(
+                preserved_tokens,
+                &unknown,
+                ExpectedKnownTokenOrder::Preserved,
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_known_token_order(
+                preserved_tokens,
+                &unknown,
+                ExpectedKnownTokenOrder::Changed,
+            )
+            .is_err()
+        );
+
+        let changed_tokens = ComparisonTokens::new(
+            &original,
+            &scrambled,
+            &prettier_original,
+            &prettier_scrambled,
+            &changed,
+        );
+        assert!(
+            validate_known_token_order(changed_tokens, &unknown, ExpectedKnownTokenOrder::Changed,)
+                .is_ok()
+        );
+        assert!(
+            validate_known_token_order(
+                changed_tokens,
+                &unknown,
+                ExpectedKnownTokenOrder::Preserved,
+            )
+            .is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a real-world Tailwind comparison harness under `tests/tailwind-compare`
- wire new `xtask compare` commands and docs to run the comparison workflow
- expand core utility and variant ordering coverage with new integration tests
- update `justfile` so the new test and compare flows are easy to run

## Testing
- Added and updated Rust integration tests for utility and parenthesized ring behavior
- Added comparison harness tests for the Tailwind fixture pipeline
- Local validation of the new workflow is covered by the updated test commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Astro `class`/`className` extraction and position mapping, including safer handling of multibyte (UTF-8) text.
  * Fixed container query variant ordering and parsing so named custom container queries are recognized and ordered consistently.

* **New Features**
  * Expanded the set of pinned corpora supported by the Tailwind comparison command.

* **Tests**
  * Added/updated regression coverage for Astro attribute ordering with multibyte text and strengthened comparison/token-matching expectations.
  * Updated integration tests for the new container-query ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->