### PR TITLE
Parse JSX and TSX source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Added
 
 - Add language-aware class extraction for HTML, Svelte, Django, Jinja, Twig,
-  Liquid, Handlebars, ERB, EJS, PHP, Blade, Lit, and Ruby
+  Liquid, Handlebars, ERB, EJS, PHP, Blade, Lit, Ruby, JSX, and TSX
+- Parse JSX and TSX with Winnow so only directly quoted `class` and `className`
+  attributes in real JSX elements are sorted
 - Add `--language` to override source-language inference and
   `--stdin-filename` to infer the language of standard input
 - Preserve template expressions as opaque boundaries while independently
@@ -44,6 +46,8 @@
 - Recognized markup languages only sort literal `class` and `className`
   attributes in actual tags. Class-like text in comments, raw-text elements,
   program strings, and dynamic or namespaced attributes is no longer rewritten
+- `SourceLanguage` now includes a `Jsx` variant used for both JSX and TSX.
+  Downstream exhaustive matches must handle it
 
 ## [0.25.2] - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ Provide a filename when sorting standard input so RustyWind can infer its templa
 
 - `cat Component.svelte | rustywind --stdin --stdin-filename Component.svelte`
 
-Supported language profiles are HTML, Svelte, Astro, Django, Jinja, Twig, Liquid, Handlebars, ERB,
-EJS, PHP, Blade, Lit, and Ruby. Astro frontmatter, expressions, dynamic class attributes, and
-`class:list` directives are preserved while static quoted class attributes are sorted. Files with
+Supported language profiles are HTML, JSX/TSX, Svelte, Astro, Django, Jinja, Twig, Liquid,
+Handlebars, ERB, EJS, PHP, Blade, Lit, and Ruby. JSX and TSX program text, comments, and dynamic
+attributes are preserved while directly quoted `class` and `className` attributes are sorted.
+Astro frontmatter, expressions, dynamic class attributes, and `class:list` directives are
+preserved while static quoted class attributes are sorted. Files with
 unrecognized extensions use conservative legacy-compatible extraction: simple static class
 attributes are sorted, while template-looking attributes remain unchanged. Because a plain `.html`
 extension does not identify its template engine, attributes with template syntax are left unchanged
@@ -160,7 +162,7 @@ Options:
   -l, --language <LANGUAGE>
           Source language to use for all inputs, overriding filename inference
 
-          [possible values: html, svelte, astro, django, jinja, twig, liquid, handlebars, erb, ejs, php, blade, lit, ruby]
+          [possible values: html, svelte, astro, jsx, tsx, django, jinja, twig, liquid, handlebars, erb, ejs, php, blade, lit, ruby]
 
   -f, --stdin-filename <PATH>
           Filename used to infer the source language of stdin

--- a/rustywind-cli/src/main.rs
+++ b/rustywind-cli/src/main.rs
@@ -322,6 +322,18 @@ mod tests {
     }
 
     #[test]
+    fn jsx_and_tsx_cli_values_share_the_jsx_profile() {
+        for language in ["jsx", "tsx"] {
+            let cli = Cli::try_parse_from(["rustywind", "--language", language, "input.js"])
+                .expect("JSX language alias should parse");
+            assert!(matches!(
+                cli.language,
+                Some(CliSourceLanguage::Jsx | CliSourceLanguage::Tsx)
+            ));
+        }
+    }
+
+    #[test]
     fn parses_stdin_filename_for_language_inference() {
         let cli = Cli::try_parse_from(["rustywind", "--stdin", "-f", "components/card.blade.php"])
             .expect("stdin filename should parse with stdin mode");

--- a/rustywind-cli/src/options.rs
+++ b/rustywind-cli/src/options.rs
@@ -57,6 +57,8 @@ pub enum CliSourceLanguage {
     Html,
     Svelte,
     Astro,
+    Jsx,
+    Tsx,
     Django,
     Jinja,
     Twig,
@@ -76,6 +78,7 @@ impl From<CliSourceLanguage> for SourceLanguage {
             CliSourceLanguage::Html => Self::Html,
             CliSourceLanguage::Svelte => Self::Svelte,
             CliSourceLanguage::Astro => Self::Astro,
+            CliSourceLanguage::Jsx | CliSourceLanguage::Tsx => Self::Jsx,
             CliSourceLanguage::Django => Self::Django,
             CliSourceLanguage::Jinja => Self::Jinja,
             CliSourceLanguage::Twig => Self::Twig,
@@ -289,5 +292,15 @@ mod tests {
             SourceLanguage::Blade
         );
         assert_eq!(resolve_source_language(None, None), SourceLanguage::Unknown);
+    }
+
+    #[test]
+    fn jsx_and_tsx_filenames_share_the_jsx_profile() {
+        for path in ["component.jsx", "component.tsx"] {
+            assert_eq!(
+                resolve_source_language(None, Some(Path::new(path))),
+                SourceLanguage::Jsx
+            );
+        }
     }
 }

--- a/rustywind-core/CHANGELOG.md
+++ b/rustywind-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add first-class Astro parsing for static quoted class attributes while preserving frontmatter,
   expressions, `class:list`, raw content, and component semantics.
+- Add first-class Winnow parsing for directly quoted JSX and TSX `class` and `className`
+  attributes while preserving host-language program text and dynamic attributes.
 - Add `-p`, `-l`, and `-f` aliases for `--tailwind-prefix`, `--language`, and
   `--stdin-filename`.
 
@@ -19,6 +21,8 @@
 ### Breaking changes
 
 - `SourceLanguage` now includes an `Astro` variant. Downstream exhaustive matches must handle it.
+- `SourceLanguage` now includes a `Jsx` variant shared by `.jsx` and `.tsx` sources. Downstream
+  exhaustive matches must handle it.
 - The default extractor for known markup languages only sorts actual quoted `class` and `className`
   attributes. Class-looking text in comments, raw elements, non-markup program expressions, and
   other attributes is no longer rewritten.

--- a/rustywind-core/src/app.rs
+++ b/rustywind-core/src/app.rs
@@ -1,10 +1,11 @@
 use std::{borrow::Cow, fmt, ops::Range};
 
 use crate::{
+    attribute_parser::{ClassAttribute, class_attributes},
     class_wrapping::ClassWrapping,
     consts::{VARIANT_SEARCHER, VARIANTS},
     hybrid_sorter::HybridSorter,
-    markup_parser::{ClassAttribute, class_attributes, is_attribute_name_character},
+    markup_parser::is_attribute_name_character,
     sorter::{FinderRegex, Sorter},
     source::{
         ClassValueAnalysis, SourceDocument, StaticRuns, analyze_class_value, is_plain_class_list,
@@ -199,7 +200,7 @@ impl RustyWind {
     /// Checks whether a source document contains a sortable static class run
     pub fn has_classes(&self, document: SourceDocument<'_>) -> bool {
         if matches!(self.regex, FinderRegex::DefaultRegex)
-            && document.language().markup_profile().is_some()
+            && document.language().attribute_parser_profile().is_some()
         {
             return class_attributes(document).is_some_and(|attributes| {
                 attributes
@@ -219,7 +220,7 @@ impl RustyWind {
     /// deduplication never crosses an expression boundary
     pub fn sort_document<'a>(&self, document: SourceDocument<'a>) -> Cow<'a, str> {
         if matches!(self.regex, FinderRegex::DefaultRegex)
-            && document.language().markup_profile().is_some()
+            && document.language().attribute_parser_profile().is_some()
         {
             return self.sort_structured_document(document);
         }

--- a/rustywind-core/src/attribute_parser.rs
+++ b/rustywind-core/src/attribute_parser.rs
@@ -1,0 +1,28 @@
+use std::ops::Range;
+
+use crate::{
+    jsx_parser, markup_parser,
+    source::{AttributeParserProfile, SourceDocument},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ClassAttribute(Range<usize>);
+
+impl ClassAttribute {
+    pub(crate) const fn new(value: Range<usize>) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn value_range(&self) -> Range<usize> {
+        self.0.clone()
+    }
+}
+
+pub(crate) fn class_attributes(document: SourceDocument<'_>) -> Option<Vec<ClassAttribute>> {
+    match document.language().attribute_parser_profile()? {
+        AttributeParserProfile::Markup(profile) => {
+            markup_parser::class_attributes(document.text(), profile)
+        }
+        AttributeParserProfile::Jsx => jsx_parser::class_attributes(document.text()),
+    }
+}

--- a/rustywind-core/src/jsx_parser.rs
+++ b/rustywind-core/src/jsx_parser.rs
@@ -14,6 +14,19 @@ use crate::{
 };
 
 type Input<'a> = LocatingSlice<&'a str>;
+const MAX_RECURSION_DEPTH: usize = 128;
+
+#[derive(Clone, Copy)]
+struct RecursionDepth(usize);
+
+impl RecursionDepth {
+    const ROOT: Self = Self(0);
+
+    fn descend(self) -> Option<Self> {
+        let depth = self.0.checked_add(1)?;
+        (depth <= MAX_RECURSION_DEPTH).then_some(Self(depth))
+    }
+}
 
 pub(crate) fn class_attributes(source: &str) -> Option<Vec<ClassAttribute>> {
     JsxParser::new(source).parse()
@@ -22,6 +35,7 @@ pub(crate) fn class_attributes(source: &str) -> Option<Vec<ClassAttribute>> {
 struct JsxParser<'a> {
     source: &'a str,
     attributes: Vec<ClassAttribute>,
+    recursion_limit_reached: bool,
 }
 
 impl<'a> JsxParser<'a> {
@@ -29,16 +43,22 @@ impl<'a> JsxParser<'a> {
         Self {
             source,
             attributes: Vec::new(),
+            recursion_limit_reached: false,
         }
     }
 
     fn parse(mut self) -> Option<Vec<ClassAttribute>> {
         let mut input = Input::new(self.source);
-        self.parse_javascript(&mut input, None)?;
+        self.parse_javascript(&mut input, None, RecursionDepth::ROOT)?;
         Some(self.attributes)
     }
 
-    fn parse_javascript(&mut self, input: &mut Input<'a>, closing: Option<char>) -> Option<()> {
+    fn parse_javascript(
+        &mut self,
+        input: &mut Input<'a>,
+        closing: Option<char>,
+        depth: RecursionDepth,
+    ) -> Option<()> {
         let mut can_start_expression = true;
 
         loop {
@@ -70,7 +90,8 @@ impl<'a> JsxParser<'a> {
                 continue;
             }
             if character == '`' {
-                self.parse_template_literal(input)?;
+                let nested_depth = self.descend(depth)?;
+                self.parse_template_literal(input, nested_depth)?;
                 can_start_expression = false;
                 continue;
             }
@@ -87,7 +108,7 @@ impl<'a> JsxParser<'a> {
             }
 
             if character == '<' && can_start_expression && is_jsx_opening_start(source.as_bytes()) {
-                if self.try_parse_jsx(input) {
+                if self.try_parse_jsx(input, depth)? {
                     can_start_expression = false;
                     continue;
                 }
@@ -98,7 +119,8 @@ impl<'a> JsxParser<'a> {
 
             if let Some(group_closing) = group_closing(character) {
                 consume_character(input, character)?;
-                self.parse_javascript(input, Some(group_closing))?;
+                let nested_depth = self.descend(depth)?;
+                self.parse_javascript(input, Some(group_closing), nested_depth)?;
                 can_start_expression = false;
                 continue;
             }
@@ -135,7 +157,11 @@ impl<'a> JsxParser<'a> {
         }
     }
 
-    fn parse_template_literal(&mut self, input: &mut Input<'a>) -> Option<()> {
+    fn parse_template_literal(
+        &mut self,
+        input: &mut Input<'a>,
+        depth: RecursionDepth,
+    ) -> Option<()> {
         consume_character(input, '`')?;
         loop {
             let source = remaining(input);
@@ -148,7 +174,8 @@ impl<'a> JsxParser<'a> {
                 '$' if source.starts_with("${") => {
                     consume_character(input, '$')?;
                     consume_character(input, '{')?;
-                    self.parse_javascript(input, Some('}'))?;
+                    let nested_depth = self.descend(depth)?;
+                    self.parse_javascript(input, Some('}'), nested_depth)?;
                 }
                 _ => {
                     any::<_, winnow::error::ContextError>
@@ -160,33 +187,38 @@ impl<'a> JsxParser<'a> {
         }
     }
 
-    fn try_parse_jsx(&mut self, input: &mut Input<'a>) -> bool {
+    fn try_parse_jsx(&mut self, input: &mut Input<'a>, depth: RecursionDepth) -> Option<bool> {
+        let nested_depth = self.descend(depth)?;
         let checkpoint = input.checkpoint();
         let attribute_count = self.attributes.len();
-        if self.parse_jsx(input).is_some() {
-            return true;
+        if self.parse_jsx(input, nested_depth).is_some() {
+            return Some(true);
         }
 
         self.attributes.truncate(attribute_count);
         input.reset(&checkpoint);
-        false
+        (!self.recursion_limit_reached).then_some(false)
     }
 
-    fn parse_jsx(&mut self, input: &mut Input<'a>) -> Option<()> {
+    fn parse_jsx(&mut self, input: &mut Input<'a>, depth: RecursionDepth) -> Option<()> {
         consume_literal(input, "<")?;
         if remaining(input).starts_with('>') {
             consume_literal(input, ">")?;
-            return self.parse_jsx_children(input, None);
+            return self.parse_jsx_children(input, None, depth);
         }
 
         let name = self.parse_jsx_name(input)?;
-        if self.parse_jsx_attributes(input)? {
+        if self.parse_jsx_attributes(input, depth)? {
             return Some(());
         }
-        self.parse_jsx_children(input, Some(name))
+        self.parse_jsx_children(input, Some(name), depth)
     }
 
-    fn parse_jsx_attributes(&mut self, input: &mut Input<'a>) -> Option<bool> {
+    fn parse_jsx_attributes(
+        &mut self,
+        input: &mut Input<'a>,
+        depth: RecursionDepth,
+    ) -> Option<bool> {
         loop {
             let whitespace: &str = multispace0::<_, winnow::error::ContextError>
                 .parse_next(input)
@@ -214,7 +246,8 @@ impl<'a> JsxParser<'a> {
 
             if remaining(input).starts_with('{') {
                 consume_character(input, '{')?;
-                self.parse_javascript(input, Some('}'))?;
+                let nested_depth = self.descend(depth)?;
+                self.parse_javascript(input, Some('}'), nested_depth)?;
                 continue;
             }
 
@@ -238,11 +271,13 @@ impl<'a> JsxParser<'a> {
                 quote @ ('\'' | '"') => Some(self.parse_quoted_attribute(input, quote)?),
                 '{' => {
                     consume_character(input, '{')?;
-                    self.parse_javascript(input, Some('}'))?;
+                    let nested_depth = self.descend(depth)?;
+                    self.parse_javascript(input, Some('}'), nested_depth)?;
                     None
                 }
                 '<' if is_jsx_opening_start(remaining(input).as_bytes()) => {
-                    self.parse_jsx(input)?;
+                    let nested_depth = self.descend(depth)?;
+                    self.parse_jsx(input, nested_depth)?;
                     None
                 }
                 _ => return None,
@@ -276,6 +311,7 @@ impl<'a> JsxParser<'a> {
         &mut self,
         input: &mut Input<'a>,
         expected_name: Option<&'a str>,
+        depth: RecursionDepth,
     ) -> Option<()> {
         loop {
             let source = remaining(input);
@@ -294,12 +330,14 @@ impl<'a> JsxParser<'a> {
                 return Some(());
             }
             if source.starts_with('<') {
-                self.parse_jsx(input)?;
+                let nested_depth = self.descend(depth)?;
+                self.parse_jsx(input, nested_depth)?;
                 continue;
             }
             if source.starts_with('{') {
                 consume_character(input, '{')?;
-                self.parse_javascript(input, Some('}'))?;
+                let nested_depth = self.descend(depth)?;
+                self.parse_javascript(input, Some('}'), nested_depth)?;
                 continue;
             }
 
@@ -342,6 +380,16 @@ impl<'a> JsxParser<'a> {
             self.parse_jsx_name_segment(input)?;
         }
         Some(&self.source[start..input.current_token_start()])
+    }
+
+    fn descend(&mut self, depth: RecursionDepth) -> Option<RecursionDepth> {
+        match depth.descend() {
+            Some(depth) => Some(depth),
+            None => {
+                self.recursion_limit_reached = true;
+                None
+            }
+        }
     }
 }
 
@@ -396,7 +444,7 @@ fn consume_character(input: &mut Input<'_>, expected: char) -> Option<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::class_attributes;
+    use super::{MAX_RECURSION_DEPTH, class_attributes};
 
     fn values(source: &str) -> Option<Vec<&str>> {
         class_attributes(source).map(|attributes| {
@@ -486,5 +534,41 @@ mod tests {
             values("const view = <div className=\"fake\">"),
             Some(Vec::new())
         );
+    }
+
+    #[test]
+    fn recursion_limit_fails_closed_across_every_recursive_syntax() {
+        let excessive_depth = MAX_RECURSION_DEPTH + 1;
+        let groups = format!(
+            "{}0{}",
+            "(".repeat(excessive_depth),
+            ")".repeat(excessive_depth)
+        );
+        let jsx = format!(
+            "{}content{}",
+            "<div>".repeat(excessive_depth),
+            "</div>".repeat(excessive_depth)
+        );
+        let templates = format!(
+            "{}0{}",
+            "`${".repeat(excessive_depth),
+            "}`".repeat(excessive_depth)
+        );
+
+        for source in [groups, jsx, templates] {
+            assert_eq!(values(&source), None);
+        }
+    }
+
+    #[test]
+    fn recursion_depth_is_restored_for_shallow_siblings() {
+        let nested_groups = MAX_RECURSION_DEPTH - 1;
+        let source = format!(
+            "{}0{}, <div className=\"p-4 flex\" />",
+            "(".repeat(nested_groups),
+            ")".repeat(nested_groups)
+        );
+
+        assert_eq!(values(&source), Some(vec!["p-4 flex"]));
     }
 }

--- a/rustywind-core/src/jsx_parser.rs
+++ b/rustywind-core/src/jsx_parser.rs
@@ -203,6 +203,15 @@ impl<'a> JsxParser<'a> {
                 return None;
             }
 
+            if remaining(input).starts_with("//") {
+                consume_line_comment(input, "//")?;
+                continue;
+            }
+            if remaining(input).starts_with("/*") {
+                consume_block_comment(input)?;
+                continue;
+            }
+
             if remaining(input).starts_with('{') {
                 consume_character(input, '{')?;
                 self.parse_javascript(input, Some('}'))?;
@@ -432,6 +441,22 @@ mod tests {
     #[test]
     fn boolean_attributes_do_not_consume_the_next_separator() {
         let source = r#"const view = <AreaChart accessibilityLayer data={chartData} className="p-4 flex" />;"#;
+
+        assert_eq!(values(source), Some(vec!["p-4 flex"]));
+    }
+
+    #[test]
+    fn comments_can_separate_attributes() {
+        let source = r#"
+            const view = (
+                <Button
+                    onClick={() => submit()}
+                    // keep this prop documented
+                    className="p-4 flex"
+                    /* and this one */ disabled
+                />
+            );
+        "#;
 
         assert_eq!(values(source), Some(vec!["p-4 flex"]));
     }

--- a/rustywind-core/src/jsx_parser.rs
+++ b/rustywind-core/src/jsx_parser.rs
@@ -1,0 +1,465 @@
+use winnow::{
+    Parser,
+    ascii::multispace0,
+    stream::{LocatingSlice, Location, Stream},
+    token::{any, literal, take_till, take_while},
+};
+
+use crate::{
+    attribute_parser::ClassAttribute,
+    template_parser::{
+        consume_block_comment, consume_escape, consume_line_comment, consume_quoted, consume_regex,
+        expression_keyword_allows_regex,
+    },
+};
+
+type Input<'a> = LocatingSlice<&'a str>;
+
+pub(crate) fn class_attributes(source: &str) -> Option<Vec<ClassAttribute>> {
+    JsxParser::new(source).parse()
+}
+
+struct JsxParser<'a> {
+    source: &'a str,
+    attributes: Vec<ClassAttribute>,
+}
+
+impl<'a> JsxParser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self {
+            source,
+            attributes: Vec::new(),
+        }
+    }
+
+    fn parse(mut self) -> Option<Vec<ClassAttribute>> {
+        let mut input = Input::new(self.source);
+        self.parse_javascript(&mut input, None)?;
+        Some(self.attributes)
+    }
+
+    fn parse_javascript(&mut self, input: &mut Input<'a>, closing: Option<char>) -> Option<()> {
+        let mut can_start_expression = true;
+
+        loop {
+            let source = remaining(input);
+            let Some(character) = source.chars().next() else {
+                return closing.is_none().then_some(());
+            };
+
+            if closing == Some(character) {
+                consume_character(input, character)?;
+                return Some(());
+            }
+            if matches!(character, ')' | ']' | '}') {
+                return None;
+            }
+
+            if source.starts_with("//") {
+                consume_line_comment(input, "//")?;
+                continue;
+            }
+            if source.starts_with("/*") {
+                consume_block_comment(input)?;
+                continue;
+            }
+
+            if matches!(character, '\'' | '"') {
+                consume_quoted(input, character, None)?;
+                can_start_expression = false;
+                continue;
+            }
+            if character == '`' {
+                self.parse_template_literal(input)?;
+                can_start_expression = false;
+                continue;
+            }
+
+            if character == '/' {
+                if can_start_expression {
+                    consume_regex(input)?;
+                    can_start_expression = false;
+                } else {
+                    consume_character(input, '/')?;
+                    can_start_expression = true;
+                }
+                continue;
+            }
+
+            if character == '<' && can_start_expression && is_jsx_opening_start(source.as_bytes()) {
+                if self.try_parse_jsx(input) {
+                    can_start_expression = false;
+                    continue;
+                }
+                consume_character(input, '<')?;
+                can_start_expression = false;
+                continue;
+            }
+
+            if let Some(group_closing) = group_closing(character) {
+                consume_character(input, character)?;
+                self.parse_javascript(input, Some(group_closing))?;
+                can_start_expression = false;
+                continue;
+            }
+
+            if is_javascript_identifier_start(character) {
+                let identifier: &str = take_while::<_, _, winnow::error::ContextError>(
+                    1..,
+                    is_javascript_identifier_continue,
+                )
+                .parse_next(input)
+                .ok()?;
+                can_start_expression = expression_keyword_allows_regex(identifier);
+                continue;
+            }
+
+            if character.is_ascii_digit() {
+                take_while::<_, _, winnow::error::ContextError>(1.., |character: char| {
+                    character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '+' | '-')
+                })
+                .void()
+                .parse_next(input)
+                .ok()?;
+                can_start_expression = false;
+                continue;
+            }
+
+            any::<_, winnow::error::ContextError>
+                .void()
+                .parse_next(input)
+                .ok()?;
+            if !character.is_whitespace() {
+                can_start_expression = true;
+            }
+        }
+    }
+
+    fn parse_template_literal(&mut self, input: &mut Input<'a>) -> Option<()> {
+        consume_character(input, '`')?;
+        loop {
+            let source = remaining(input);
+            match source.chars().next()? {
+                '\\' => consume_escape(input)?,
+                '`' => {
+                    consume_character(input, '`')?;
+                    return Some(());
+                }
+                '$' if source.starts_with("${") => {
+                    consume_character(input, '$')?;
+                    consume_character(input, '{')?;
+                    self.parse_javascript(input, Some('}'))?;
+                }
+                _ => {
+                    any::<_, winnow::error::ContextError>
+                        .void()
+                        .parse_next(input)
+                        .ok()?;
+                }
+            }
+        }
+    }
+
+    fn try_parse_jsx(&mut self, input: &mut Input<'a>) -> bool {
+        let checkpoint = input.checkpoint();
+        let attribute_count = self.attributes.len();
+        if self.parse_jsx(input).is_some() {
+            return true;
+        }
+
+        self.attributes.truncate(attribute_count);
+        input.reset(&checkpoint);
+        false
+    }
+
+    fn parse_jsx(&mut self, input: &mut Input<'a>) -> Option<()> {
+        consume_literal(input, "<")?;
+        if remaining(input).starts_with('>') {
+            consume_literal(input, ">")?;
+            return self.parse_jsx_children(input, None);
+        }
+
+        let name = self.parse_jsx_name(input)?;
+        if self.parse_jsx_attributes(input)? {
+            return Some(());
+        }
+        self.parse_jsx_children(input, Some(name))
+    }
+
+    fn parse_jsx_attributes(&mut self, input: &mut Input<'a>) -> Option<bool> {
+        loop {
+            let whitespace: &str = multispace0::<_, winnow::error::ContextError>
+                .parse_next(input)
+                .ok()?;
+            if remaining(input).starts_with("/>") {
+                consume_literal(input, "/>")?;
+                return Some(true);
+            }
+            if remaining(input).starts_with('>') {
+                consume_literal(input, ">")?;
+                return Some(false);
+            }
+            if whitespace.is_empty() {
+                return None;
+            }
+
+            if remaining(input).starts_with('{') {
+                consume_character(input, '{')?;
+                self.parse_javascript(input, Some('}'))?;
+                continue;
+            }
+
+            let name = self.parse_jsx_attribute_name(input)?;
+            let after_name = input.checkpoint();
+            multispace0::<_, winnow::error::ContextError>
+                .void()
+                .parse_next(input)
+                .ok()?;
+            if !remaining(input).starts_with('=') {
+                input.reset(&after_name);
+                continue;
+            }
+
+            consume_literal(input, "=")?;
+            multispace0::<_, winnow::error::ContextError>
+                .void()
+                .parse_next(input)
+                .ok()?;
+            let value = match remaining(input).chars().next()? {
+                quote @ ('\'' | '"') => Some(self.parse_quoted_attribute(input, quote)?),
+                '{' => {
+                    consume_character(input, '{')?;
+                    self.parse_javascript(input, Some('}'))?;
+                    None
+                }
+                '<' if is_jsx_opening_start(remaining(input).as_bytes()) => {
+                    self.parse_jsx(input)?;
+                    None
+                }
+                _ => return None,
+            };
+
+            if matches!(name, "class" | "className")
+                && let Some(value) = value
+            {
+                self.attributes.push(ClassAttribute::new(value));
+            }
+        }
+    }
+
+    fn parse_quoted_attribute(
+        &self,
+        input: &mut Input<'a>,
+        quote: char,
+    ) -> Option<std::ops::Range<usize>> {
+        consume_character(input, quote)?;
+        let start = input.current_token_start();
+        take_till::<_, _, winnow::error::ContextError>(0.., |character| character == quote)
+            .void()
+            .parse_next(input)
+            .ok()?;
+        let end = input.current_token_start();
+        consume_character(input, quote)?;
+        Some(start..end)
+    }
+
+    fn parse_jsx_children(
+        &mut self,
+        input: &mut Input<'a>,
+        expected_name: Option<&'a str>,
+    ) -> Option<()> {
+        loop {
+            let source = remaining(input);
+            if source.starts_with("</") {
+                consume_literal(input, "</")?;
+                match expected_name {
+                    Some(expected_name) if self.parse_jsx_name(input)? == expected_name => {}
+                    None if remaining(input).starts_with('>') => {}
+                    Some(_) | None => return None,
+                }
+                multispace0::<_, winnow::error::ContextError>
+                    .void()
+                    .parse_next(input)
+                    .ok()?;
+                consume_literal(input, ">")?;
+                return Some(());
+            }
+            if source.starts_with('<') {
+                self.parse_jsx(input)?;
+                continue;
+            }
+            if source.starts_with('{') {
+                consume_character(input, '{')?;
+                self.parse_javascript(input, Some('}'))?;
+                continue;
+            }
+
+            take_till::<_, _, winnow::error::ContextError>(1.., ('<', '{'))
+                .void()
+                .parse_next(input)
+                .ok()?;
+        }
+    }
+
+    fn parse_jsx_name(&self, input: &mut Input<'a>) -> Option<&'a str> {
+        let start = input.current_token_start();
+        self.parse_jsx_name_segment(input)?;
+        while matches!(remaining(input).chars().next(), Some('.' | ':')) {
+            any::<_, winnow::error::ContextError>
+                .void()
+                .parse_next(input)
+                .ok()?;
+            self.parse_jsx_name_segment(input)?;
+        }
+        Some(&self.source[start..input.current_token_start()])
+    }
+
+    fn parse_jsx_name_segment(&self, input: &mut Input<'a>) -> Option<()> {
+        let first = remaining(input).chars().next()?;
+        if !is_jsx_name_start(first) {
+            return None;
+        }
+        take_while::<_, _, winnow::error::ContextError>(1.., is_jsx_name_continue)
+            .void()
+            .parse_next(input)
+            .ok()
+    }
+
+    fn parse_jsx_attribute_name(&self, input: &mut Input<'a>) -> Option<&'a str> {
+        let start = input.current_token_start();
+        self.parse_jsx_name_segment(input)?;
+        if remaining(input).starts_with(':') {
+            consume_literal(input, ":")?;
+            self.parse_jsx_name_segment(input)?;
+        }
+        Some(&self.source[start..input.current_token_start()])
+    }
+}
+
+fn group_closing(opening: char) -> Option<char> {
+    match opening {
+        '(' => Some(')'),
+        '[' => Some(']'),
+        '{' => Some('}'),
+        _ => None,
+    }
+}
+
+fn is_jsx_opening_start(source: &[u8]) -> bool {
+    source
+        .get(1)
+        .is_some_and(|byte| byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$' | b'>'))
+}
+
+fn is_jsx_name_start(character: char) -> bool {
+    character.is_alphabetic() || matches!(character, '_' | '$')
+}
+
+fn is_jsx_name_continue(character: char) -> bool {
+    character.is_alphanumeric() || matches!(character, '_' | '$' | '-')
+}
+
+fn is_javascript_identifier_start(character: char) -> bool {
+    character.is_alphabetic() || matches!(character, '_' | '$')
+}
+
+fn is_javascript_identifier_continue(character: char) -> bool {
+    character.is_alphanumeric() || matches!(character, '_' | '$')
+}
+
+fn remaining<'a>(input: &Input<'a>) -> &'a str {
+    input.as_ref()
+}
+
+fn consume_literal(input: &mut Input<'_>, value: &str) -> Option<()> {
+    literal::<_, _, winnow::error::ContextError>(value)
+        .void()
+        .parse_next(input)
+        .ok()
+}
+
+fn consume_character(input: &mut Input<'_>, expected: char) -> Option<()> {
+    let character = any::<_, winnow::error::ContextError>
+        .parse_next(input)
+        .ok()?;
+    (character == expected).then_some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::class_attributes;
+
+    fn values(source: &str) -> Option<Vec<&str>> {
+        class_attributes(source).map(|attributes| {
+            attributes
+                .into_iter()
+                .map(|attribute| &source[attribute.value_range()])
+                .collect()
+        })
+    }
+
+    #[test]
+    fn extracts_nested_quoted_attributes() {
+        let source = r#"const view = <><div className="p-4 flex"><Icon class='size-4 block' /></div><svg:path class="stroke-2" /></>;"#;
+
+        assert_eq!(
+            values(source),
+            Some(vec!["p-4 flex", "size-4 block", "stroke-2"])
+        );
+    }
+
+    #[test]
+    fn ignores_program_text_and_dynamic_attributes() {
+        let source = r#"
+            const string = '<div className="fake string" />';
+            const template = `<div class="fake template">${value}</div>`;
+            const pattern = /<div className="fake regex">/;
+            // <div className="fake line comment" />
+            /* <div class="fake block comment" /> */
+            const view = <div data-class="ignored" className={value} {...props} class="real p-4" />;
+        "#;
+
+        assert_eq!(values(source), Some(vec!["real p-4"]));
+    }
+
+    #[test]
+    fn parses_jsx_inside_javascript_expressions() {
+        let source = r#"const view = condition ? <Panel render={<span className="p-4 flex" />} /> : <div class='m-2 grid' />;"#;
+
+        assert_eq!(values(source), Some(vec!["p-4 flex", "m-2 grid"]));
+    }
+
+    #[test]
+    fn boolean_attributes_do_not_consume_the_next_separator() {
+        let source = r#"const view = <AreaChart accessibilityLayer data={chartData} className="p-4 flex" />;"#;
+
+        assert_eq!(values(source), Some(vec!["p-4 flex"]));
+    }
+
+    #[test]
+    fn generic_and_relational_syntax_is_not_jsx() {
+        let source = r#"
+            const identity = <T,>(value: T): T => value;
+            const result = left < right && right > left;
+            const view = <div className="p-4 flex" />;
+        "#;
+
+        assert_eq!(values(source), Some(vec!["p-4 flex"]));
+    }
+
+    #[test]
+    fn incomplete_lexical_constructs_fail_closed() {
+        for source in [
+            r#"const value = "unterminated <div className='fake'>"#,
+            "/* unterminated <div className=\"fake\">",
+            "const value = `unterminated <div className=\"fake\">",
+        ] {
+            assert_eq!(values(source), None, "{source}");
+        }
+
+        assert_eq!(
+            values("const view = <div className=\"fake\">"),
+            Some(Vec::new())
+        );
+    }
+}

--- a/rustywind-core/src/lib.rs
+++ b/rustywind-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! Use [`RustyWind::sort_document`] with a [`SourceDocument`] so RustyWind can
 //! distinguish static class text from embedded template code
 pub mod app;
+mod attribute_parser;
 mod class_name;
 pub mod class_wrapping;
 pub mod consts;
@@ -16,6 +17,7 @@ mod template_parser;
 // Pattern-based sorting modules
 pub mod class_parser;
 pub mod hybrid_sorter;
+mod jsx_parser;
 mod markup_parser;
 pub mod pattern_sorter;
 pub mod property_order;

--- a/rustywind-core/src/markup_parser.rs
+++ b/rustywind-core/src/markup_parser.rs
@@ -7,9 +7,10 @@ use winnow::{
     token::{any, literal, take_till, take_until, take_while},
 };
 
+use crate::attribute_parser::ClassAttribute;
 use crate::source::{
-    MarkupDialect, MarkupProfile, SourceDocument, StatelessTemplateSyntax, TemplateIslandEnd,
-    TemplateIslandSyntax, template_island_end_at,
+    MarkupDialect, MarkupProfile, StatelessTemplateSyntax, TemplateIslandEnd, TemplateIslandSyntax,
+    template_island_end_at,
 };
 use crate::template_parser::{
     ExpressionSyntax, SvelteBlockKind, SvelteBraceContext, SvelteBraceEvent, SvelteBraceScan,
@@ -18,18 +19,11 @@ use crate::template_parser::{
 
 type Input<'a> = LocatingSlice<&'a str>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ClassAttribute(Range<usize>);
-
-impl ClassAttribute {
-    pub(crate) fn value_range(&self) -> Range<usize> {
-        self.0.clone()
-    }
-}
-
-pub(crate) fn class_attributes(document: SourceDocument<'_>) -> Option<Vec<ClassAttribute>> {
-    let profile = document.language().markup_profile()?;
-    MarkupParser::new(document.text(), profile).parse()
+pub(crate) fn class_attributes(
+    source: &str,
+    profile: MarkupProfile,
+) -> Option<Vec<ClassAttribute>> {
+    MarkupParser::new(source, profile).parse()
 }
 
 struct MarkupParser<'a> {
@@ -219,7 +213,7 @@ impl<'a> MarkupParser<'a> {
                 || attribute.name == "className")
                 && let Some(value) = attribute.quoted_value
             {
-                self.attributes.push(ClassAttribute(value));
+                self.attributes.push(ClassAttribute::new(value));
             }
         }
     }
@@ -598,10 +592,10 @@ fn consume_slice(input: &mut Input<'_>, slice: &str) -> Option<()> {
 #[cfg(test)]
 mod tests {
     use super::class_attributes;
-    use crate::source::{SourceDocument, SourceLanguage};
+    use crate::source::SourceLanguage;
 
     fn values(source: &str, language: SourceLanguage) -> Option<Vec<&str>> {
-        class_attributes(SourceDocument::new(source, language)).map(|attributes| {
+        class_attributes(source, language.markup_profile()?).map(|attributes| {
             attributes
                 .into_iter()
                 .map(|attribute| &source[attribute.value_range()])

--- a/rustywind-core/src/source.rs
+++ b/rustywind-core/src/source.rs
@@ -34,6 +34,8 @@ pub enum SourceLanguage {
     Svelte,
     /// Astro components
     Astro,
+    /// JSX syntax embedded in JavaScript or TypeScript
+    Jsx,
     /// Django templates
     Django,
     /// Jinja templates
@@ -92,6 +94,7 @@ impl SourceLanguage {
             Some("html" | "htm") => Self::Html,
             Some("svelte") => Self::Svelte,
             Some("astro") => Self::Astro,
+            Some("jsx" | "tsx") => Self::Jsx,
             Some("django" | "djhtml") => Self::Django,
             Some("jinja" | "jinja2" | "j2") => Self::Jinja,
             Some("twig") => Self::Twig,
@@ -110,6 +113,22 @@ impl SourceLanguage {
     pub(crate) const fn markup_profile(self) -> Option<MarkupProfile> {
         SourceProfile::new(self).markup
     }
+
+    pub(crate) const fn attribute_parser_profile(self) -> Option<AttributeParserProfile> {
+        match self {
+            Self::Jsx => Some(AttributeParserProfile::Jsx),
+            _ => match self.markup_profile() {
+                Some(profile) => Some(AttributeParserProfile::Markup(profile)),
+                None => None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttributeParserProfile {
+    Markup(MarkupProfile),
+    Jsx,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -121,7 +140,7 @@ struct SourceProfile {
 impl SourceProfile {
     const fn new(language: SourceLanguage) -> Self {
         let markup = match language {
-            SourceLanguage::Unknown => None,
+            SourceLanguage::Jsx | SourceLanguage::Unknown => None,
             SourceLanguage::Html => Some(MarkupProfile::new(
                 MarkupDialect::Html,
                 TemplateIslandSyntax::Stateless(StatelessTemplateSyntax::None),
@@ -183,9 +202,10 @@ impl SourceProfile {
             )),
         };
         let class_values = match language {
-            SourceLanguage::Html | SourceLanguage::Astro | SourceLanguage::Unknown => {
-                ClassValueSyntax::Unspecified
-            }
+            SourceLanguage::Html
+            | SourceLanguage::Astro
+            | SourceLanguage::Jsx
+            | SourceLanguage::Unknown => ClassValueSyntax::Unspecified,
             SourceLanguage::Svelte => ClassValueSyntax::Balanced {
                 opener: "{",
                 expression: ExpressionSyntax::JavaScript,
@@ -492,6 +512,8 @@ mod tests {
             ("index.HTML", SourceLanguage::Html),
             ("component.svelte", SourceLanguage::Svelte),
             ("component.astro", SourceLanguage::Astro),
+            ("component.jsx", SourceLanguage::Jsx),
+            ("component.TSX", SourceLanguage::Jsx),
             ("page.django.html", SourceLanguage::Django),
             ("page.jinja2", SourceLanguage::Jinja),
             ("page.twig", SourceLanguage::Twig),

--- a/rustywind-core/src/template_parser.rs
+++ b/rustywind-core/src/template_parser.rs
@@ -657,7 +657,7 @@ impl ExpressionParser {
     }
 }
 
-fn consume_line_comment(input: &mut Input<'_>, opener: &str) -> Option<()> {
+pub(crate) fn consume_line_comment(input: &mut Input<'_>, opener: &str) -> Option<()> {
     literal::<_, _, winnow::error::ContextError>(opener)
         .void()
         .parse_next(input)
@@ -672,7 +672,7 @@ fn consume_line_comment(input: &mut Input<'_>, opener: &str) -> Option<()> {
         .ok()
 }
 
-fn consume_block_comment(input: &mut Input<'_>) -> Option<()> {
+pub(crate) fn consume_block_comment(input: &mut Input<'_>) -> Option<()> {
     (
         literal::<_, _, winnow::error::ContextError>("/*"),
         winnow::token::take_until::<_, _, winnow::error::ContextError>(0.., "*/"),
@@ -694,7 +694,11 @@ fn consume_html_comment(input: &mut Input<'_>) -> Option<()> {
         .ok()
 }
 
-fn consume_quoted(input: &mut Input<'_>, quote: char, rejected: Option<&str>) -> Option<()> {
+pub(crate) fn consume_quoted(
+    input: &mut Input<'_>,
+    quote: char,
+    rejected: Option<&str>,
+) -> Option<()> {
     consume_character(input, quote)?;
     loop {
         let source = remaining(input);
@@ -715,7 +719,7 @@ fn consume_quoted(input: &mut Input<'_>, quote: char, rejected: Option<&str>) ->
     }
 }
 
-fn consume_escape(input: &mut Input<'_>) -> Option<()> {
+pub(crate) fn consume_escape(input: &mut Input<'_>) -> Option<()> {
     consume_character(input, '\\')?;
     any::<_, winnow::error::ContextError>
         .void()
@@ -723,7 +727,7 @@ fn consume_escape(input: &mut Input<'_>) -> Option<()> {
         .ok()
 }
 
-fn consume_regex(input: &mut Input<'_>) -> Option<()> {
+pub(crate) fn consume_regex(input: &mut Input<'_>) -> Option<()> {
     consume_character(input, '/')?;
     let mut in_character_class = false;
     loop {
@@ -765,7 +769,7 @@ fn consume_character(input: &mut Input<'_>, expected: char) -> Option<()> {
     (character == expected).then_some(())
 }
 
-fn expression_keyword_allows_regex(identifier: &str) -> bool {
+pub(crate) fn expression_keyword_allows_regex(identifier: &str) -> bool {
     matches!(
         identifier,
         "await"

--- a/rustywind-core/tests/template_aware_sorting.rs
+++ b/rustywind-core/tests/template_aware_sorting.rs
@@ -241,6 +241,34 @@ fn astro_expressions_distinguish_program_strings_from_nested_markup() {
 }
 
 #[test]
+fn jsx_and_tsx_sort_only_direct_quoted_class_attributes() {
+    let source = r#"const fake = '<div className="p-4 flex" />';
+// <div class="p-4 flex" />
+type Props<T> = { value: T };
+const Component = <T,>({ value }: Props<T>) => (
+  <>
+    <div className="p-4 flex" data-class="p-4 flex">
+      {value ? <span class='m-4 grid' /> : <span className={classes} />}
+    </div>
+  </>
+);"#;
+    let expected = r#"const fake = '<div className="p-4 flex" />';
+// <div class="p-4 flex" />
+type Props<T> = { value: T };
+const Component = <T,>({ value }: Props<T>) => (
+  <>
+    <div className="flex p-4" data-class="p-4 flex">
+      {value ? <span class='m-4 grid' /> : <span className={classes} />}
+    </div>
+  </>
+);"#;
+
+    for path in ["Component.jsx", "Component.tsx"] {
+        assert_eq!(sort_path(source, path), expected);
+    }
+}
+
+#[test]
 fn relational_expressions_are_not_treated_as_markup() {
     let astro = r#"{a<b && className="p-4 m-4" > c}<div class="p-4 m-4"></div>"#;
     assert_eq!(

--- a/tests/tailwind-compare/README.md
+++ b/tests/tailwind-compare/README.md
@@ -1,8 +1,8 @@
 # Tailwind comparison engine
 
 This package compares RustyWind's ordering of static quoted class attributes
-with Prettier's Tailwind CSS plugin across a pinned external corpus. It supports
-TSX, Svelte, and Astro sources. The engine reverses eligible class lists in
+with Prettier's Tailwind CSS plugin across pinned external corpora. It supports
+JSX, TSX, Svelte, and Astro sources. The engine reverses eligible class lists in
 memory, formats both the original and scrambled source with Prettier, and runs
 RustyWind on the scrambled source. This avoids false agreement from
 already-sorted source while detecting formatter output that depends on input
@@ -41,6 +41,10 @@ The process exits nonzero for invalid arguments, missing inputs, and a failed
 Tailwind classification probe. Source parse errors and RustyWind failures are
 recorded in the report for the caller to interpret alongside ordering and
 extraction findings.
+
+RustyWind may only change bytes inside real quoted `class` and `className`
+attribute values. Any change to program text, comments, dynamic attributes, or
+other source bytes is recorded as a failing source-preservation error.
 
 Schema version 2 classifies each attribute independently. Attribute-count and
 token-multiset mismatches take precedence. When both Prettier runs preserve the

--- a/tests/tailwind-compare/compare.mjs
+++ b/tests/tailwind-compare/compare.mjs
@@ -25,6 +25,7 @@ import {
   extractAttributes,
   kinds,
   orderCandidates,
+  preservesSourceOutsideAttributes,
   same,
   scrambleAttributes,
   splitClassTokens,
@@ -41,6 +42,7 @@ const ignoredDirectories = new Set([
 ]);
 const syntaxPlugins = {
   astro: [astroPlugin],
+  jsx: [],
   svelte: [sveltePlugin],
   tsx: [],
 };
@@ -49,7 +51,7 @@ function usage() {
   return [
     "usage: node compare.mjs",
     "  --corpus NAME --repo PATH --revision REVISION --scope PATH",
-    "  --kind tsx|svelte|astro --limit COUNT --rustywind PATH",
+    "  --kind jsx|tsx|svelte|astro --limit COUNT --rustywind PATH",
     "  --stylesheet PATH --output PATH",
   ].join("\n");
 }
@@ -228,6 +230,7 @@ function prettierOptions(configuration, file) {
     filepath: file,
     parser: kinds[configuration.kind].parser,
     plugins: [...syntaxPlugins[configuration.kind], tailwindPlugin],
+    tailwindPreserveDuplicates: true,
     tailwindStylesheet: configuration.stylesheet,
   };
 }
@@ -249,7 +252,13 @@ function scrubError(error, configuration) {
 function runRustywind(configuration, candidate) {
   const result = spawnSync(
     configuration.rustywind,
-    ["--stdin", "--stdin-filename", candidate.file, "--quiet"],
+    [
+      "--stdin",
+      "--stdin-filename",
+      candidate.file,
+      "--allow-duplicates",
+      "--quiet",
+    ],
     {
       encoding: "utf8",
       input: candidate.scrambledSource,
@@ -312,6 +321,7 @@ export async function probeKnownClasses(tokens, stylesheet) {
 async function validatePrettier(configuration) {
   const fixtures = {
     astro: '---\n---\n<div class="p-4 flex"></div>\n',
+    jsx: '<div className="p-4 flex" />;\n',
     svelte: '<div class="p-4 flex"></div>\n',
     tsx: '<div className="p-4 flex" />;\n',
   };
@@ -425,6 +435,31 @@ async function compareCandidates(configuration, candidates) {
       failures.push({
         path: candidate.path,
         stage: "rustywind",
+        error: scrubError(error, configuration),
+      });
+      continue;
+    }
+
+    try {
+      if (
+        !preservesSourceOutsideAttributes(
+          candidate.scrambledSource,
+          rustywindOutput,
+          configuration.kind,
+        )
+      ) {
+        failures.push({
+          path: candidate.path,
+          stage: "rustywind-source-preservation",
+          error:
+            "RustyWind changed source outside quoted class attribute values",
+        });
+        continue;
+      }
+    } catch (error) {
+      failures.push({
+        path: candidate.path,
+        stage: "rustywind-source-preservation",
         error: scrubError(error, configuration),
       });
       continue;

--- a/tests/tailwind-compare/lib.mjs
+++ b/tests/tailwind-compare/lib.mjs
@@ -65,16 +65,31 @@ function findReactAttributes(source, kind) {
   return attributes;
 }
 
-function findSvelteAttributes(source) {
+function findStaticSvelteAttributes(source) {
   const ast = parseSvelte(source, { modern: true });
   const attributes = [];
   walk(ast.fragment, (node) => {
     if (
       node.type !== "Attribute" ||
-      !isClassAttributeName(node.name)
+      !isClassAttributeName(node.name) ||
+      node.value?.length !== 1 ||
+      node.value[0].type !== "Text"
     ) {
       return;
     }
+    const { start, end } = node.value[0];
+    const quote = source[start - 1];
+    if ((quote !== '"' && quote !== "'") || source[end] !== quote) return;
+    attributes.push({ end, start });
+  });
+  return attributes;
+}
+
+function findQuotedSvelteAttributes(source) {
+  const ast = parseSvelte(source, { modern: true });
+  const attributes = [];
+  walk(ast.fragment, (node) => {
+    if (node.type !== "Attribute" || !isClassAttributeName(node.name)) return;
     const valueStart = source.indexOf("=", node.name_loc.end.character) + 1;
     if (valueStart === 0 || valueStart >= node.end) return;
     const quoteStart = source
@@ -166,7 +181,7 @@ function findStaticAttributes(source, kind) {
   if (kind === "jsx" || kind === "tsx") {
     attributes = findReactAttributes(source, kind);
   } else if (kind === "svelte") {
-    attributes = findSvelteAttributes(source);
+    attributes = findStaticSvelteAttributes(source);
   } else if (kind === "astro") {
     attributes = findAstroAttributes(source);
   } else {
@@ -194,7 +209,7 @@ function findQuotedAttributes(source, kind) {
   if (kind === "jsx" || kind === "tsx") {
     attributes = findReactAttributes(source, kind);
   } else if (kind === "svelte") {
-    attributes = findSvelteAttributes(source);
+    attributes = findQuotedSvelteAttributes(source);
   } else if (kind === "astro") {
     attributes = findAstroAttributes(source);
   } else {

--- a/tests/tailwind-compare/lib.mjs
+++ b/tests/tailwind-compare/lib.mjs
@@ -1,11 +1,13 @@
 import { createHash } from "node:crypto";
 
 import { parse as parseAstro } from "@astrojs/compiler/sync";
+import { parsers as babelParsers } from "prettier/plugins/babel";
 import { parsers as typescriptParsers } from "prettier/plugins/typescript";
 import { parse as parseSvelte } from "svelte/compiler";
 
 export const kinds = Object.freeze({
   astro: { extension: ".astro", parser: "astro" },
+  jsx: { extension: ".jsx", parser: "babel" },
   svelte: { extension: ".svelte", parser: "svelte" },
   tsx: { extension: ".tsx", parser: "typescript" },
 });
@@ -34,21 +36,28 @@ function isClassAttributeName(name) {
   return name === "class" || name === "className";
 }
 
-function findTsxAttributes(source) {
-  const ast = typescriptParsers.typescript.parse(source, {
-    filepath: "source.tsx",
-  });
+function findReactAttributes(source, kind) {
+  const ast =
+    kind === "jsx"
+      ? babelParsers.babel.parse(source, { filepath: "source.jsx" })
+      : typescriptParsers.typescript.parse(source, {
+          filepath: "source.tsx",
+        });
   const attributes = [];
   walk(ast, (node) => {
+    const valueType = kind === "jsx" ? "StringLiteral" : "Literal";
     if (
       node.type !== "JSXAttribute" ||
       !isClassAttributeName(node.name?.name) ||
-      node.value?.type !== "Literal" ||
+      node.value?.type !== valueType ||
       typeof node.value.value !== "string"
     ) {
       return;
     }
-    const [start, end] = node.value.range;
+    const [start, end] =
+      kind === "jsx"
+        ? [node.value.start, node.value.end]
+        : node.value.range;
     const quote = source[start];
     if ((quote !== '"' && quote !== "'") || source[end - 1] !== quote) return;
     attributes.push({ end: end - 1, start: start + 1 });
@@ -62,16 +71,22 @@ function findSvelteAttributes(source) {
   walk(ast.fragment, (node) => {
     if (
       node.type !== "Attribute" ||
-      !isClassAttributeName(node.name) ||
-      node.value?.length !== 1 ||
-      node.value[0].type !== "Text"
+      !isClassAttributeName(node.name)
     ) {
       return;
     }
-    const { start, end } = node.value[0];
-    const quote = source[start - 1];
-    if ((quote !== '"' && quote !== "'") || source[end] !== quote) return;
-    attributes.push({ end, start });
+    const valueStart = source.indexOf("=", node.name_loc.end.character) + 1;
+    if (valueStart === 0 || valueStart >= node.end) return;
+    const quoteStart = source
+      .slice(valueStart, node.end)
+      .search(/[^\s]/u);
+    if (quoteStart === -1) return;
+    const start = valueStart + quoteStart;
+    const quote = source[start];
+    if ((quote !== '"' && quote !== "'") || source[node.end - 1] !== quote) {
+      return;
+    }
+    attributes.push({ end: node.end - 1, start: start + 1 });
   });
   return attributes;
 }
@@ -148,8 +163,8 @@ function findAstroAttributes(source) {
 
 function findStaticAttributes(source, kind) {
   let attributes;
-  if (kind === "tsx") {
-    attributes = findTsxAttributes(source);
+  if (kind === "jsx" || kind === "tsx") {
+    attributes = findReactAttributes(source, kind);
   } else if (kind === "svelte") {
     attributes = findSvelteAttributes(source);
   } else if (kind === "astro") {
@@ -160,6 +175,43 @@ function findStaticAttributes(source, kind) {
   return attributes
     .filter(({ start, end }) => isStaticCandidate(source.slice(start, end)))
     .sort((left, right) => left.start - right.start);
+}
+
+export function preservesSourceOutsideAttributes(before, after, kind) {
+  const beforeAttributes = findQuotedAttributes(before, kind);
+  const afterAttributes = findQuotedAttributes(after, kind);
+  if (beforeAttributes.length !== afterAttributes.length) return false;
+
+  const beforeSegments = sourceSegments(before, beforeAttributes);
+  const afterSegments = sourceSegments(after, afterAttributes);
+  return beforeSegments.every(
+    (segment, index) => segment === afterSegments[index],
+  );
+}
+
+function findQuotedAttributes(source, kind) {
+  let attributes;
+  if (kind === "jsx" || kind === "tsx") {
+    attributes = findReactAttributes(source, kind);
+  } else if (kind === "svelte") {
+    attributes = findSvelteAttributes(source);
+  } else if (kind === "astro") {
+    attributes = findAstroAttributes(source);
+  } else {
+    throw new Error(`Unsupported source kind: ${kind}`);
+  }
+  return attributes.sort((left, right) => left.start - right.start);
+}
+
+function sourceSegments(source, attributes) {
+  const segments = [];
+  let cursor = 0;
+  for (const { start, end } of attributes) {
+    segments.push(source.slice(cursor, start));
+    cursor = end;
+  }
+  segments.push(source.slice(cursor));
+  return segments;
 }
 
 export function extractAttributes(source, kind) {

--- a/tests/tailwind-compare/test/lib.test.mjs
+++ b/tests/tailwind-compare/test/lib.test.mjs
@@ -88,6 +88,18 @@ test("permits changes only inside real quoted class attributes", () => {
   );
 });
 
+test("preserves dynamic quoted Svelte attributes without scrambling them", () => {
+  const source = '<div class="p-4 {active ? \'flex\' : \'grid\'}"></div>';
+  const changed = source.replace("p-4", "m-4");
+
+  assert.deepEqual(extractAttributes(source, "svelte"), []);
+  assert.equal(scrambleAttributes(source, "svelte"), source);
+  assert.equal(
+    preservesSourceOutsideAttributes(source, changed, "svelte"),
+    true,
+  );
+});
+
 test("ignores markup text in source comments and string literals", () => {
   const fixtures = [
     {

--- a/tests/tailwind-compare/test/lib.test.mjs
+++ b/tests/tailwind-compare/test/lib.test.mjs
@@ -12,6 +12,7 @@ import {
   corpusFingerprint,
   extractAttributes,
   orderCandidates,
+  preservesSourceOutsideAttributes,
   scrambleAttributes,
   splitClassTokens,
 } from "../lib.mjs";
@@ -29,6 +30,62 @@ test("extracts only static quoted class attributes", () => {
     "grid gap-2",
     "before:content-['{']",
   ]);
+});
+
+test("converts Astro byte offsets after multibyte source text", () => {
+  const source = `---
+---
+<div>·</div>
+<div class="flex p-4"></div>
+`;
+  const changed = source.replace("flex p-4", "p-4 flex");
+
+  assert.deepEqual(extractAttributes(source, "astro"), ["flex p-4"]);
+  assert.equal(preservesSourceOutsideAttributes(source, changed, "astro"), true);
+});
+
+test("extracts JSX through the Babel parser", () => {
+  const source = `
+    const sample = '<div className="fake string">';
+    export const view = <><div className="flex p-4" /><span class='grid gap-2' /></>;
+  `;
+
+  assert.deepEqual(extractAttributes(source, "jsx"), [
+    "flex p-4",
+    "grid gap-2",
+  ]);
+});
+
+test("permits changes only inside real quoted class attributes", () => {
+  const source = `
+    const sample = '<div className="fake string">';
+    const view = <div className="p-4 flex" className={dynamic} />;
+  `;
+
+  assert.equal(
+    preservesSourceOutsideAttributes(
+      source,
+      source.replace('className="p-4 flex"', 'className="flex p-4"'),
+      "tsx",
+    ),
+    true,
+  );
+  assert.equal(
+    preservesSourceOutsideAttributes(
+      source,
+      source.replace("fake string", "string fake"),
+      "tsx",
+    ),
+    false,
+  );
+  assert.equal(
+    preservesSourceOutsideAttributes(
+      source,
+      source.replace("className={dynamic}", "className={changed}"),
+      "tsx",
+    ),
+    false,
+  );
 });
 
 test("ignores markup text in source comments and string literals", () => {

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -10,7 +10,8 @@ This crate provides developer automation tools for the RustyWind project, replac
 
 ### compare run
 
-Compare RustyWind against immutable snapshots of real-world Tailwind projects.
+Compare RustyWind against immutable snapshots of real-world JSX, TSX, Svelte,
+and Astro Tailwind projects.
 
 ```bash
 # compare every corpus

--- a/xtask/src/commands/compare.rs
+++ b/xtask/src/commands/compare.rs
@@ -22,6 +22,8 @@ pub(crate) enum CorpusName {
     #[value(name = "shadcn-ui")]
     ShadcnUi,
     Tremor,
+    #[value(name = "horizon-ui")]
+    HorizonUi,
     #[value(name = "shadcn-svelte")]
     ShadcnSvelte,
     #[value(name = "flowbite-svelte")]
@@ -36,6 +38,7 @@ impl CorpusName {
         match self {
             Self::ShadcnUi => "shadcn-ui",
             Self::Tremor => "tremor",
+            Self::HorizonUi => "horizon-ui",
             Self::ShadcnSvelte => "shadcn-svelte",
             Self::FlowbiteSvelte => "flowbite-svelte",
             Self::Astrowind => "astrowind",
@@ -52,6 +55,7 @@ impl fmt::Display for CorpusName {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum CorpusKind {
+    Jsx,
     Tsx,
     Svelte,
     Astro,
@@ -60,6 +64,7 @@ enum CorpusKind {
 impl CorpusKind {
     fn as_str(self) -> &'static str {
         match self {
+            Self::Jsx => "jsx",
             Self::Tsx => "tsx",
             Self::Svelte => "svelte",
             Self::Astro => "astro",
@@ -137,6 +142,19 @@ const CORPORA: &[CorpusSpec] = &[
             files: 40,
             attributes: 560,
             fingerprint: "2b1c2815ba2f41173d6a2c5b3f95e790671ba56a1e699949c27cc437ee85f13e",
+        },
+    ),
+    CorpusSpec::new(
+        CorpusName::HorizonUi,
+        "horizon-ui/horizon-tailwind-react",
+        "8f17779f2b45419112f32541bb555817dabc5b7c",
+        "src",
+        CorpusKind::Jsx,
+        40,
+        ExpectedCorpus {
+            files: 40,
+            attributes: 670,
+            fingerprint: "9a648ab9c1f7722c8bda8eeca5cef2c3dda3e3742bb80486f48f629bfa14355c",
         },
     ),
     CorpusSpec::new(
@@ -1650,6 +1668,7 @@ mod tests {
             vec![
                 CorpusName::ShadcnUi,
                 CorpusName::Tremor,
+                CorpusName::HorizonUi,
                 CorpusName::ShadcnSvelte,
                 CorpusName::FlowbiteSvelte,
                 CorpusName::Astrowind,
@@ -1662,13 +1681,18 @@ mod tests {
     fn explicit_selection_is_deduplicated_and_uses_canonical_order() {
         let selected = select_corpora(&[
             CorpusName::Astrowind,
+            CorpusName::HorizonUi,
             CorpusName::ShadcnUi,
             CorpusName::Astrowind,
         ]);
 
         assert_eq!(
             selected.iter().map(|spec| spec.name).collect::<Vec<_>>(),
-            vec![CorpusName::ShadcnUi, CorpusName::Astrowind]
+            vec![
+                CorpusName::ShadcnUi,
+                CorpusName::HorizonUi,
+                CorpusName::Astrowind
+            ]
         );
     }
 


### PR DESCRIPTION
## Summary

- add a shared Winnow-backed JSX source profile for `.jsx` and `.tsx`
- sort only directly quoted `class` and `className` attributes in real JSX elements
- preserve JavaScript and TypeScript strings, comments, templates, regexes, generics, and dynamic attributes
- add a pinned Horizon UI JSX corpus and enforce source preservation across every real-world corpus

## Why

JSX and TSX previously used the unknown-language regex fallback. That sorted simple attributes, but it could not reliably distinguish JSX attributes from class-like text in the surrounding program. The real-world comparison suite also lacked a JSX corpus and did not verify that formatter changes stayed inside parsed attribute values.

## Impact

JSX and TSX files now receive syntax-aware handling through `SourceLanguage::Jsx`, whether inferred from a filename or selected with `--language jsx` or `--language tsx`. Static quoted attributes are sorted while dynamic expressions and other source text remain unchanged.

This adds a public `SourceLanguage` variant, so downstream exhaustive matches must handle `Jsx`.

## Validation

- `just fmt`
- `just clippy`
- `cargo test --workspace --no-fail-fast`
- `npm test`
- `cargo xtask compare run --offline`
  - Shadcn UI TSX: 834 attributes
  - Horizon UI JSX: 670 attributes
  - Shadcn Svelte: 713 attributes
  - Astrowind: 362 attributes

All four corpora passed with zero extraction mismatches, known-order mismatches, or source-preservation failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSX/TSX support for sorting only directly quoted `class`/`className` attributes.
  * Added `jsx` and `tsx` CLI language options, with `.jsx`/`.tsx` files handled automatically.

* **Bug Fixes**
  * Improved extraction to avoid touching class-like text in strings, comments, regexes, or dynamic expressions.
  * Strengthened source preservation so only real quoted class attributes are reordered.

* **Documentation**
  * Updated usage, CLI help, and comparison docs to reflect JSX/TSX support.

* **Breaking Changes**
  * Language detection now includes a `Jsx` variant shared by `.jsx` and `.tsx`, requiring downstream exhaustive handling updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->