### PR TITLE
Add `--json` flag for result report in json format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `--json` to the check, dry-run, bare, write, and stdin modes to emit one
+  machine-readable JSON document with changed files, changed class-group counts,
+  proposed or written content, and structured `{path, message}` errors for
+  unreadable files and failed directory walks
+- Bare `rustywind --json PATH` behaves like `--dry-run --json` and never writes
+  files; dry-run JSON includes the full formatted content of each changed file
+
+### Fixed
+
+- Replace the panic on unreadable stdin with a normal error message
+
 ## [0.26.0] - 2026-07-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,7 @@ dependencies = [
  "rustywind_vite",
  "serde",
  "serde_json",
+ "shlex",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,6 @@ dependencies = [
  "rustywind_vite",
  "serde",
  "serde_json",
- "shlex",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -553,6 +569,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +659,12 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
@@ -1217,6 +1245,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1478,7 @@ version = "0.26.0"
 dependencies = [
  "ahash",
  "anstyle",
+ "assert_cmd",
  "clap",
  "color-eyre",
  "colored",
@@ -1438,6 +1494,7 @@ dependencies = [
  "rustywind_vite",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -1679,6 +1736,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "test-case"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +1975,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ Run in CI, exit with error if unsorted classes are found:
 
 - `rustywind --check-formatted .`
 
+Add `--json` to any of these modes to print a single machine-readable JSON document instead of the
+human output:
+
+- `rustywind --check-formatted --json .`
+- `rustywind --dry-run --json .`
+- `rustywind --write --json .`
+- `echo "<FILE CONTENTS>" | rustywind --stdin --json`
+
+Bare `rustywind --json .` behaves like `--dry-run --json` and never writes files. Unlike the human
+dry run, dry-run JSON includes the full formatted content of every file that would change under
+`proposed_changes`, so automation can apply the result without a second run. Each document reports
+`ok` (formatting is clean and nothing failed; for `--write`, every write succeeded) and an `errors`
+array of `{path, message}` entries for unreadable files or failed directory walks. The exit code is
+`1` when `--check-formatted` finds unformatted files, and in every JSON mode when `errors` is
+non-empty; dry-run and stdin JSON still exit `0` when changes are merely proposed.
+
 Run RustyWind with a custom sorter. The `config_file.json` should have a top level entry of `sortOrder`
 which is an array with the classes listed in the order you want them sorted.
 
@@ -109,6 +125,9 @@ To print only the file names that would be changed run with the `--check-formatt
 If you want to run it on your STDIN, you can do:
   echo "<FILE CONTENTS>" | rustywind --stdin
 
+Add `--json` to check, preview, write, or stdin modes for machine-readable output
+  rustywind --check-formatted --json .
+
 Arguments:
   [PATH]...
           A file or directory to run on
@@ -125,6 +144,9 @@ Options:
 
       --check-formatted
           Checks if the files are already formatted, exits with 1 if not formatted
+
+      --json
+          Emits one machine-readable JSON document
 
       --allow-duplicates
           When set, RustyWind will not delete duplicated classes

--- a/rustywind-cli/Cargo.toml
+++ b/rustywind-cli/Cargo.toml
@@ -50,4 +50,5 @@ rayon = "1.10"
 
 [dev-dependencies]
 assert_cmd = "2.0"
+shlex = "1.3"
 tempfile = "3.10"

--- a/rustywind-cli/Cargo.toml
+++ b/rustywind-cli/Cargo.toml
@@ -47,3 +47,7 @@ serde_json = "1.0"
 
 # parallelism
 rayon = "1.10"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+tempfile = "3.10"

--- a/rustywind-cli/Cargo.toml
+++ b/rustywind-cli/Cargo.toml
@@ -50,5 +50,4 @@ rayon = "1.10"
 
 [dev-dependencies]
 assert_cmd = "2.0"
-shlex = "1.3"
 tempfile = "3.10"

--- a/rustywind-cli/src/json.rs
+++ b/rustywind-cli/src/json.rs
@@ -1,0 +1,774 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fs;
+use std::io::{self, ErrorKind, Read};
+use std::path::{Path, PathBuf};
+
+use ignore::{Error as WalkError, WalkBuilder};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rustywind_core::SourceDocument;
+use serde::Serialize;
+
+use crate::options::{Options, WriteMode};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum JsonMode {
+    CheckFormatted,
+    DryRun,
+    Write,
+    Stdin,
+}
+
+impl JsonMode {
+    fn from_write_mode(write_mode: WriteMode) -> Self {
+        match write_mode {
+            WriteMode::CheckFormatted => Self::CheckFormatted,
+            WriteMode::DryRun | WriteMode::ToConsole => Self::DryRun,
+            WriteMode::ToFile => Self::Write,
+            WriteMode::ToStdOut => Self::Stdin,
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::CheckFormatted => "check-formatted",
+            Self::DryRun => "dry-run",
+            Self::Write => "write",
+            Self::Stdin => "stdin",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PathInfo {
+    original: PathBuf,
+    canonical: Option<PathBuf>,
+}
+
+impl PathInfo {
+    fn new(path: PathBuf) -> Self {
+        let canonical = path.canonicalize().ok();
+        Self {
+            original: path,
+            canonical,
+        }
+    }
+
+    fn identity(&self, current_dir: &Path) -> PathBuf {
+        self.canonical
+            .clone()
+            .unwrap_or_else(|| absolute_path(&self.original, current_dir))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PendingError {
+    path: PathInfo,
+    message: String,
+}
+
+#[derive(Debug)]
+struct Discovery {
+    candidates: Vec<PathInfo>,
+    errors: Vec<PendingError>,
+}
+
+#[derive(Debug)]
+struct FileResult {
+    path: PathInfo,
+    outcome: FileOutcome,
+}
+
+#[derive(Debug)]
+enum FileOutcome {
+    ReadError(String),
+    Changed(ChangedFile),
+}
+
+#[derive(Debug)]
+struct ChangedFile {
+    content: String,
+    unsorted_classes: usize,
+    write: WriteStatus,
+}
+
+#[derive(Debug)]
+enum WriteStatus {
+    NotAttempted,
+    Written,
+    Failed(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct FormattingFile {
+    path: String,
+    unsorted_classes: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct ProposedChange {
+    path: String,
+    content: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct WrittenFile {
+    path: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct ErrorEntry {
+    path: String,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckResponse {
+    mode: &'static str,
+    ok: bool,
+    files_needing_formatting: Vec<FormattingFile>,
+    errors: Vec<ErrorEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct DryRunResponse {
+    mode: &'static str,
+    ok: bool,
+    files_needing_formatting: Vec<FormattingFile>,
+    proposed_changes: Vec<ProposedChange>,
+    errors: Vec<ErrorEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct WriteResponse {
+    mode: &'static str,
+    ok: bool,
+    files_needing_formatting: Vec<FormattingFile>,
+    written_files: Vec<WrittenFile>,
+    errors: Vec<ErrorEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct StdinResponse {
+    mode: &'static str,
+    ok: bool,
+    unsorted_classes: usize,
+    content: String,
+    errors: Vec<ErrorEntry>,
+}
+
+#[derive(Debug)]
+struct AggregatedFiles {
+    files_needing_formatting: Vec<FormattingFile>,
+    proposed_changes: Vec<ProposedChange>,
+    written_files: Vec<WrittenFile>,
+    errors: Vec<ErrorEntry>,
+}
+
+pub(crate) fn run(options: &Options) -> bool {
+    let mode = JsonMode::from_write_mode(options.write_mode);
+    if mode == JsonMode::Stdin {
+        return run_stdin(options, std::io::stdin());
+    }
+
+    run_files(options, mode)
+}
+
+fn run_stdin(options: &Options, reader: impl Read) -> bool {
+    let response = match super::read_input(reader) {
+        Ok(contents) => {
+            let language = options.stdin_source_language();
+            let report = options
+                .rustywind
+                .sort_document_with_report(SourceDocument::new(&contents, language));
+            StdinResponse {
+                mode: JsonMode::Stdin.as_str(),
+                ok: report.changed_class_groups == 0,
+                unsorted_classes: report.changed_class_groups,
+                content: report.contents.into_owned(),
+                errors: Vec::new(),
+            }
+        }
+        Err(error) => StdinResponse {
+            mode: JsonMode::Stdin.as_str(),
+            ok: false,
+            unsorted_classes: 0,
+            content: String::new(),
+            errors: vec![ErrorEntry {
+                path: "<stdin>".to_string(),
+                message: error.to_string(),
+            }],
+        },
+    };
+    let failed = !response.errors.is_empty();
+    emit(&response);
+    failed
+}
+
+fn run_files(options: &Options, mode: JsonMode) -> bool {
+    let discovery = discover_files(&options.starting_paths);
+    let results = discovery
+        .candidates
+        .into_par_iter()
+        .filter_map(|path| process_file(path, options, mode))
+        .collect::<Vec<_>>();
+    let aggregated = aggregate_files(discovery.errors, results, &options.starting_paths);
+    let clean = aggregated.files_needing_formatting.is_empty() && aggregated.errors.is_empty();
+    let has_errors = !aggregated.errors.is_empty();
+
+    match mode {
+        JsonMode::CheckFormatted => {
+            emit(&CheckResponse {
+                mode: mode.as_str(),
+                ok: clean,
+                files_needing_formatting: aggregated.files_needing_formatting,
+                errors: aggregated.errors,
+            });
+            !clean
+        }
+        JsonMode::DryRun => {
+            emit(&DryRunResponse {
+                mode: mode.as_str(),
+                ok: clean,
+                files_needing_formatting: aggregated.files_needing_formatting,
+                proposed_changes: aggregated.proposed_changes,
+                errors: aggregated.errors,
+            });
+            has_errors
+        }
+        JsonMode::Write => {
+            emit(&WriteResponse {
+                mode: mode.as_str(),
+                ok: !has_errors,
+                files_needing_formatting: aggregated.files_needing_formatting,
+                written_files: aggregated.written_files,
+                errors: aggregated.errors,
+            });
+            has_errors
+        }
+        JsonMode::Stdin => unreachable!("stdin handled before file discovery"),
+    }
+}
+
+fn emit(response: &impl Serialize) {
+    let json = serde_json::to_string(response).expect("JSON wire structs should serialize");
+    println!("{json}");
+}
+
+fn discover_files(starting_paths: &[PathBuf]) -> Discovery {
+    let mut candidates = Vec::new();
+    let mut errors = Vec::new();
+
+    for starting_path in starting_paths {
+        for item in WalkBuilder::new(starting_path).build() {
+            match item {
+                Ok(entry) => {
+                    if let Some(error) = entry.error() {
+                        flatten_walk_error(error, entry.path(), &mut errors);
+                    }
+
+                    let is_file = if entry.path_is_symlink() {
+                        match entry.metadata() {
+                            Ok(metadata) => metadata.is_file(),
+                            Err(error) => {
+                                flatten_walk_error(&error, entry.path(), &mut errors);
+                                false
+                            }
+                        }
+                    } else {
+                        entry
+                            .file_type()
+                            .is_some_and(|file_type| file_type.is_file())
+                    };
+
+                    if is_file {
+                        candidates.push(PathInfo::new(entry.into_path()));
+                    }
+                }
+                Err(error) => flatten_walk_error(&error, starting_path, &mut errors),
+            }
+        }
+    }
+
+    candidates.sort_by(|left, right| left.original.cmp(&right.original));
+    let current_dir = std::env::current_dir().unwrap_or_default();
+    let mut seen = HashSet::new();
+    candidates.retain(|candidate| seen.insert(candidate.identity(&current_dir)));
+
+    Discovery { candidates, errors }
+}
+
+fn flatten_walk_error(error: &WalkError, fallback: &Path, output: &mut Vec<PendingError>) {
+    flatten_walk_error_with_context(error, fallback, fallback, &[], output);
+}
+
+fn flatten_walk_error_with_context(
+    error: &WalkError,
+    fallback: &Path,
+    current_path: &Path,
+    context: &[String],
+    output: &mut Vec<PendingError>,
+) {
+    match error {
+        WalkError::Partial(errors) => {
+            for error in errors {
+                flatten_walk_error_with_context(error, fallback, current_path, context, output);
+            }
+        }
+        WalkError::WithLineNumber { line, err } => {
+            let mut nested_context = context.to_vec();
+            nested_context.push(format!("line {line}"));
+            flatten_walk_error_with_context(err, fallback, current_path, &nested_context, output);
+        }
+        WalkError::WithPath { path, err } => {
+            flatten_walk_error_with_context(err, fallback, path, context, output);
+        }
+        WalkError::WithDepth { depth, err } => {
+            let mut nested_context = context.to_vec();
+            nested_context.push(format!("depth {depth}"));
+            flatten_walk_error_with_context(err, fallback, current_path, &nested_context, output);
+        }
+        WalkError::Loop { child, .. } => push_walk_error(child, error, context, output),
+        _ => push_walk_error(
+            if current_path.as_os_str().is_empty() {
+                fallback
+            } else {
+                current_path
+            },
+            error,
+            context,
+            output,
+        ),
+    }
+}
+
+fn push_walk_error(
+    path: &Path,
+    error: &WalkError,
+    context: &[String],
+    output: &mut Vec<PendingError>,
+) {
+    let message = if context.is_empty() {
+        error.to_string()
+    } else {
+        format!("{}: {error}", context.join(": "))
+    };
+    output.push(PendingError {
+        path: PathInfo::new(path.to_path_buf()),
+        message,
+    });
+}
+
+fn process_file(path: PathInfo, options: &Options, mode: JsonMode) -> Option<FileResult> {
+    process_file_with(
+        path,
+        options,
+        mode,
+        |path| fs::read_to_string(path),
+        |path, contents| fs::write(path, contents),
+    )
+}
+
+fn process_file_with(
+    path: PathInfo,
+    options: &Options,
+    mode: JsonMode,
+    read: impl FnOnce(&Path) -> io::Result<String>,
+    write: impl FnOnce(&Path, &[u8]) -> io::Result<()>,
+) -> Option<FileResult> {
+    if super::should_ignore_current_file(&options.ignored_files, &path.original) {
+        return None;
+    }
+
+    let contents = match read(&path.original) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == ErrorKind::InvalidData => return None,
+        Err(error) => {
+            return Some(FileResult {
+                path,
+                outcome: FileOutcome::ReadError(error.to_string()),
+            });
+        }
+    };
+    let language = options.source_language_for_path(&path.original);
+    let report = options
+        .rustywind
+        .sort_document_with_report(SourceDocument::new(&contents, language));
+    if report.changed_class_groups == 0 {
+        return None;
+    }
+
+    let content = report.contents.into_owned();
+    let write_status = if mode == JsonMode::Write {
+        match write(&path.original, content.as_bytes()) {
+            Ok(()) => WriteStatus::Written,
+            Err(error) => WriteStatus::Failed(error.to_string()),
+        }
+    } else {
+        WriteStatus::NotAttempted
+    };
+
+    Some(FileResult {
+        path,
+        outcome: FileOutcome::Changed(ChangedFile {
+            content,
+            unsorted_classes: report.changed_class_groups,
+            write: write_status,
+        }),
+    })
+}
+
+fn aggregate_files(
+    discovery_errors: Vec<PendingError>,
+    files: Vec<FileResult>,
+    starting_paths: &[PathBuf],
+) -> AggregatedFiles {
+    let current_dir = std::env::current_dir().unwrap_or_default();
+    let paths = discovery_errors
+        .iter()
+        .map(|error| &error.path)
+        .chain(files.iter().map(|file| &file.path));
+    let resolved_paths = resolve_display_paths(paths, starting_paths, &current_dir);
+    let display = |path: &PathInfo| {
+        resolved_paths
+            .get(&path.identity(&current_dir))
+            .expect("every collected path should have a resolved display path")
+            .clone()
+    };
+
+    let mut files_needing_formatting = Vec::new();
+    let mut proposed_changes = Vec::new();
+    let mut written_files = Vec::new();
+    let mut errors = discovery_errors
+        .into_iter()
+        .map(|error| ErrorEntry {
+            path: display(&error.path),
+            message: error.message,
+        })
+        .collect::<Vec<_>>();
+
+    for file in files {
+        let path = display(&file.path);
+        match file.outcome {
+            FileOutcome::ReadError(message) => errors.push(ErrorEntry { path, message }),
+            FileOutcome::Changed(changed) => {
+                files_needing_formatting.push(FormattingFile {
+                    path: path.clone(),
+                    unsorted_classes: changed.unsorted_classes,
+                });
+                proposed_changes.push(ProposedChange {
+                    path: path.clone(),
+                    content: changed.content,
+                });
+                match changed.write {
+                    WriteStatus::NotAttempted => (),
+                    WriteStatus::Written => written_files.push(WrittenFile { path }),
+                    WriteStatus::Failed(message) => errors.push(ErrorEntry { path, message }),
+                }
+            }
+        }
+    }
+
+    files_needing_formatting.sort_by(|left, right| left.path.cmp(&right.path));
+    proposed_changes.sort_by(|left, right| left.path.cmp(&right.path));
+    written_files.sort_by(|left, right| left.path.cmp(&right.path));
+    errors.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.message.cmp(&right.message))
+    });
+    errors.dedup();
+
+    AggregatedFiles {
+        files_needing_formatting,
+        proposed_changes,
+        written_files,
+        errors,
+    }
+}
+
+fn resolve_display_paths<'a>(
+    paths: impl Iterator<Item = &'a PathInfo>,
+    starting_paths: &[PathBuf],
+    current_dir: &Path,
+) -> HashMap<PathBuf, String> {
+    let mut representatives = BTreeMap::<PathBuf, PathInfo>::new();
+    for path in paths {
+        let identity = path.identity(current_dir);
+        representatives
+            .entry(identity)
+            .and_modify(|existing| {
+                if path.original < existing.original {
+                    *existing = path.clone();
+                }
+            })
+            .or_insert_with(|| path.clone());
+    }
+
+    let mut displays = representatives
+        .iter()
+        .map(|(identity, path)| {
+            (
+                identity.clone(),
+                super::get_file_name(&path.original, starting_paths),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    replace_collisions(&mut displays, &representatives, |path| {
+        cwd_relative(&path.original, current_dir)
+            .display()
+            .to_string()
+    });
+    replace_collisions(&mut displays, &representatives, |path| {
+        path.canonical
+            .clone()
+            .unwrap_or_else(|| absolute_path(&path.original, current_dir))
+            .display()
+            .to_string()
+    });
+
+    displays
+}
+
+fn replace_collisions(
+    displays: &mut HashMap<PathBuf, String>,
+    representatives: &BTreeMap<PathBuf, PathInfo>,
+    replacement: impl Fn(&PathInfo) -> String,
+) {
+    let mut groups = HashMap::<String, Vec<PathBuf>>::new();
+    for (identity, display) in displays.iter() {
+        groups
+            .entry(display.clone())
+            .or_default()
+            .push(identity.clone());
+    }
+    for identities in groups.into_values().filter(|group| group.len() > 1) {
+        for identity in identities {
+            let path = representatives
+                .get(&identity)
+                .expect("display identity should have a representative");
+            displays.insert(identity, replacement(path));
+        }
+    }
+}
+
+fn cwd_relative<'a>(path: &'a Path, current_dir: &Path) -> &'a Path {
+    if path.is_absolute() {
+        path.strip_prefix(current_dir).unwrap_or(path)
+    } else {
+        path
+    }
+}
+
+fn absolute_path(path: &Path, current_dir: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        current_dir.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::io::{self, ErrorKind};
+    use std::path::PathBuf;
+
+    use clap::Parser;
+    use serde_json::Value;
+
+    use super::{
+        CheckResponse, DryRunResponse, ErrorEntry, FileOutcome, FormattingFile, JsonMode, PathInfo,
+        ProposedChange, StdinResponse, WriteResponse, WriteStatus, WrittenFile, process_file_with,
+    };
+    use crate::{Cli, options::Options};
+
+    fn keys(value: &Value) -> BTreeSet<&str> {
+        value
+            .as_object()
+            .expect("response should be an object")
+            .keys()
+            .map(String::as_str)
+            .collect()
+    }
+
+    #[test]
+    fn check_shape_has_only_check_fields() {
+        let value = serde_json::to_value(CheckResponse {
+            mode: "check-formatted",
+            ok: true,
+            files_needing_formatting: Vec::new(),
+            errors: Vec::new(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            keys(&value),
+            BTreeSet::from(["errors", "files_needing_formatting", "mode", "ok"])
+        );
+        assert_eq!(value["files_needing_formatting"], Value::Array(vec![]));
+        assert_eq!(value["errors"], Value::Array(vec![]));
+    }
+
+    #[test]
+    fn dry_run_shape_has_only_preview_fields() {
+        let value = serde_json::to_value(DryRunResponse {
+            mode: "dry-run",
+            ok: false,
+            files_needing_formatting: vec![FormattingFile {
+                path: "input.html".to_string(),
+                unsorted_classes: 1,
+            }],
+            proposed_changes: vec![ProposedChange {
+                path: "input.html".to_string(),
+                content: "sorted".to_string(),
+            }],
+            errors: Vec::new(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            keys(&value),
+            BTreeSet::from([
+                "errors",
+                "files_needing_formatting",
+                "mode",
+                "ok",
+                "proposed_changes"
+            ])
+        );
+    }
+
+    #[test]
+    fn write_shape_has_only_write_fields() {
+        let value = serde_json::to_value(WriteResponse {
+            mode: "write",
+            ok: true,
+            files_needing_formatting: Vec::new(),
+            written_files: Vec::new(),
+            errors: Vec::new(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            keys(&value),
+            BTreeSet::from([
+                "errors",
+                "files_needing_formatting",
+                "mode",
+                "ok",
+                "written_files"
+            ])
+        );
+        assert_eq!(value["written_files"], Value::Array(vec![]));
+    }
+
+    #[test]
+    fn stdin_shape_has_only_stdin_fields() {
+        let value = serde_json::to_value(StdinResponse {
+            mode: "stdin",
+            ok: true,
+            unsorted_classes: 0,
+            content: String::new(),
+            errors: Vec::new(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            keys(&value),
+            BTreeSet::from(["content", "errors", "mode", "ok", "unsorted_classes"])
+        );
+        assert_eq!(value["content"], "");
+    }
+
+    #[test]
+    fn processing_skips_invalid_utf8_and_reports_other_read_errors() {
+        let options = Options::new_from_cli(
+            Cli::try_parse_from(["rustywind", "--json", "input.html"]).unwrap(),
+        )
+        .unwrap();
+        let invalid = process_file_with(
+            PathInfo::new(PathBuf::from("input.html")),
+            &options,
+            JsonMode::DryRun,
+            |_| Err(io::Error::new(ErrorKind::InvalidData, "binary")),
+            |_, _| Ok(()),
+        );
+        assert!(invalid.is_none());
+
+        let unreadable = process_file_with(
+            PathInfo::new(PathBuf::from("input.html")),
+            &options,
+            JsonMode::DryRun,
+            |_| Err(io::Error::new(ErrorKind::PermissionDenied, "denied")),
+            |_, _| Ok(()),
+        );
+        let Some(unreadable) = unreadable else {
+            panic!("ordinary read errors should be retained");
+        };
+        let FileOutcome::ReadError(message) = unreadable.outcome else {
+            panic!("read failure should be a read error outcome");
+        };
+        assert_eq!(message, "denied");
+    }
+
+    #[test]
+    fn processing_retains_change_when_write_fails() {
+        let options = Options::new_from_cli(
+            Cli::try_parse_from(["rustywind", "--write", "--json", "input.html"]).unwrap(),
+        )
+        .unwrap();
+        let result = process_file_with(
+            PathInfo::new(PathBuf::from("input.html")),
+            &options,
+            JsonMode::Write,
+            |_| Ok(r#"<div class="p-4 m-4"></div>"#.to_string()),
+            |_, _| Err(io::Error::new(ErrorKind::StorageFull, "disk full")),
+        );
+        let Some(file) = result else {
+            panic!("changed file should produce a result");
+        };
+        let FileOutcome::Changed(changed) = file.outcome else {
+            panic!("a changed file with a failed write should stay a change");
+        };
+
+        assert!(
+            matches!(changed.write, WriteStatus::Failed(ref message) if message == "disk full")
+        );
+    }
+
+    #[test]
+    fn error_entry_wire_fields_are_required() {
+        let value = serde_json::to_value(ErrorEntry {
+            path: "missing.html".to_string(),
+            message: "not found".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(keys(&value), BTreeSet::from(["message", "path"]));
+    }
+
+    #[test]
+    fn file_entry_wire_fields_are_required() {
+        let formatting = serde_json::to_value(FormattingFile {
+            path: "input.html".to_string(),
+            unsorted_classes: 2,
+        })
+        .unwrap();
+        let proposed = serde_json::to_value(ProposedChange {
+            path: "input.html".to_string(),
+            content: "content".to_string(),
+        })
+        .unwrap();
+        let written = serde_json::to_value(WrittenFile {
+            path: "input.html".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            keys(&formatting),
+            BTreeSet::from(["path", "unsorted_classes"])
+        );
+        assert_eq!(keys(&proposed), BTreeSet::from(["content", "path"]));
+        assert_eq!(keys(&written), BTreeSet::from(["path"]));
+    }
+}

--- a/rustywind-cli/src/json.rs
+++ b/rustywind-cli/src/json.rs
@@ -98,26 +98,45 @@ enum WriteStatus {
     Failed(String),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(transparent)]
+struct JsonPath(String);
+
+impl From<String> for JsonPath {
+    fn from(path: String) -> Self {
+        #[cfg(windows)]
+        let path = path.replace('\\', "/");
+
+        Self(path)
+    }
+}
+
+impl From<&str> for JsonPath {
+    fn from(path: &str) -> Self {
+        Self::from(path.to_string())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 struct FormattingFile {
-    path: String,
+    path: JsonPath,
     unsorted_classes: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 struct ProposedChange {
-    path: String,
+    path: JsonPath,
     content: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 struct WrittenFile {
-    path: String,
+    path: JsonPath,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 struct ErrorEntry {
-    path: String,
+    path: JsonPath,
     message: String,
 }
 
@@ -194,7 +213,7 @@ fn run_stdin(options: &Options, reader: impl Read) -> bool {
             unsorted_classes: 0,
             content: String::new(),
             errors: vec![ErrorEntry {
-                path: "<stdin>".to_string(),
+                path: "<stdin>".into(),
                 message: error.to_string(),
             }],
         },
@@ -490,7 +509,7 @@ fn resolve_display_paths<'a>(
     paths: impl Iterator<Item = &'a PathInfo>,
     starting_paths: &[PathBuf],
     current_dir: &Path,
-) -> HashMap<PathBuf, String> {
+) -> HashMap<PathBuf, JsonPath> {
     let mut representatives = BTreeMap::<PathBuf, PathInfo>::new();
     for path in paths {
         let identity = path.identity(current_dir);
@@ -509,7 +528,7 @@ fn resolve_display_paths<'a>(
         .map(|(identity, path)| {
             (
                 identity.clone(),
-                super::get_file_name(&path.original, starting_paths),
+                super::get_file_name(&path.original, starting_paths).into(),
             )
         })
         .collect::<HashMap<_, _>>();
@@ -517,6 +536,7 @@ fn resolve_display_paths<'a>(
         cwd_relative(&path.original, current_dir)
             .display()
             .to_string()
+            .into()
     });
     replace_collisions(&mut displays, &representatives, |path| {
         path.canonical
@@ -524,17 +544,18 @@ fn resolve_display_paths<'a>(
             .unwrap_or_else(|| absolute_path(&path.original, current_dir))
             .display()
             .to_string()
+            .into()
     });
 
     displays
 }
 
 fn replace_collisions(
-    displays: &mut HashMap<PathBuf, String>,
+    displays: &mut HashMap<PathBuf, JsonPath>,
     representatives: &BTreeMap<PathBuf, PathInfo>,
-    replacement: impl Fn(&PathInfo) -> String,
+    replacement: impl Fn(&PathInfo) -> JsonPath,
 ) {
-    let mut groups = HashMap::<String, Vec<PathBuf>>::new();
+    let mut groups = HashMap::<JsonPath, Vec<PathBuf>>::new();
     for (identity, display) in displays.iter() {
         groups
             .entry(display.clone())
@@ -615,11 +636,11 @@ mod tests {
             mode: "dry-run",
             ok: false,
             files_needing_formatting: vec![FormattingFile {
-                path: "input.html".to_string(),
+                path: "input.html".into(),
                 unsorted_classes: 1,
             }],
             proposed_changes: vec![ProposedChange {
-                path: "input.html".to_string(),
+                path: "input.html".into(),
                 content: "sorted".to_string(),
             }],
             errors: Vec::new(),
@@ -739,7 +760,7 @@ mod tests {
     #[test]
     fn error_entry_wire_fields_are_required() {
         let value = serde_json::to_value(ErrorEntry {
-            path: "missing.html".to_string(),
+            path: "missing.html".into(),
             message: "not found".to_string(),
         })
         .unwrap();
@@ -750,17 +771,17 @@ mod tests {
     #[test]
     fn file_entry_wire_fields_are_required() {
         let formatting = serde_json::to_value(FormattingFile {
-            path: "input.html".to_string(),
+            path: "input.html".into(),
             unsorted_classes: 2,
         })
         .unwrap();
         let proposed = serde_json::to_value(ProposedChange {
-            path: "input.html".to_string(),
+            path: "input.html".into(),
             content: "content".to_string(),
         })
         .unwrap();
         let written = serde_json::to_value(WrittenFile {
-            path: "input.html".to_string(),
+            path: "input.html".into(),
         })
         .unwrap();
 

--- a/rustywind-cli/src/main.rs
+++ b/rustywind-cli/src/main.rs
@@ -1,13 +1,13 @@
 mod cli;
+mod json;
 mod options;
 
 use ahash::AHashSet as HashSet;
-use clap::Parser;
-use eyre::Result;
+use clap::{CommandFactory, Parser, error::ErrorKind};
+use eyre::{Context, Result};
 use indoc::indoc;
 use once_cell::sync::Lazy;
-use options::Options;
-use options::WriteMode;
+use options::{Options, OutputFormat, WriteMode};
 use rayon::ThreadPoolBuilder;
 use rayon::iter::IntoParallelRefIterator as _;
 use rayon::iter::ParallelIterator;
@@ -39,7 +39,10 @@ static GRAY: Lazy<colored::CustomColor> = Lazy::new(|| colored::CustomColor::new
       rustywind --check-formatted .
 
     If you want to run it on your STDIN, you can do:
-      echo \"<FILE CONTENTS>\" | rustywind --stdin"))]
+      echo \"<FILE CONTENTS>\" | rustywind --stdin
+
+    Add `--json` to check, preview, write, or stdin modes for machine-readable output
+      rustywind --check-formatted --json ."))]
 pub struct Cli {
     /// A file or directory to run on.
     #[arg(value_name = "PATH", required_unless_present = "stdin")]
@@ -60,6 +63,9 @@ pub struct Cli {
     /// Checks if the files are already formatted, exits with 1 if not formatted.
     #[arg(long, conflicts_with_all = &["stdin", "write", "dry_run"])]
     check_formatted: bool,
+    /// Emits one machine-readable JSON document.
+    #[arg(long)]
+    json: bool,
     /// When set, RustyWind will not delete duplicated classes.
     #[arg(long)]
     allow_duplicates: bool,
@@ -108,8 +114,21 @@ pub struct Cli {
     )]
     stdin_filename: Option<PathBuf>,
     /// Do not print log messages
-    #[arg(long, default_value = "false", conflicts_with_all = &["dry_run"])]
+    #[arg(long, default_value = "false")]
     quiet: bool,
+}
+
+impl Cli {
+    fn validate(&self) -> std::result::Result<(), clap::Error> {
+        if self.quiet && self.dry_run && !self.json {
+            return Err(Cli::command().error(
+                ErrorKind::ArgumentConflict,
+                "the argument '--quiet' cannot be used with '--dry-run'",
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 fn main() -> Result<()> {
@@ -117,8 +136,17 @@ fn main() -> Result<()> {
     color_eyre::install()?;
 
     let cli = Cli::parse();
+    cli.validate().unwrap_or_else(|error| error.exit());
 
     let mut options = Options::new_from_cli(cli)?;
+
+    if options.output_format == OutputFormat::Json {
+        let failed = json::run(&options);
+        if failed {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
 
     let search_paths = std::mem::take(&mut options.search_paths);
 
@@ -145,7 +173,7 @@ fn main() -> Result<()> {
     }
 
     if let WriteMode::ToStdOut = &options.write_mode {
-        let contents = options.stdin.clone().unwrap_or_default();
+        let contents = read_input(std::io::stdin()).wrap_err("Unable to read STDIN")?;
         let language = options.stdin_source_language();
 
         if rustywind.has_classes(SourceDocument::new(&contents, language)) {
@@ -238,6 +266,12 @@ fn print_changed_files(file_path: &Path, contents_changed: bool, options: &Optio
             eprintln!("  * [UNFORMATTED FILE] {file_name}")
         }
     }
+}
+
+fn read_input(mut reader: impl std::io::Read) -> std::io::Result<String> {
+    let mut contents = String::new();
+    reader.read_to_string(&mut contents)?;
+    Ok(contents)
 }
 
 /// Return a boolean indicating whether the file should be ignored
@@ -355,6 +389,37 @@ mod tests {
     #[test]
     fn rejects_unknown_source_language() {
         assert!(Cli::try_parse_from(["rustywind", "--language", "unknown", "input.html"]).is_err());
+    }
+
+    #[test]
+    fn quiet_dry_run_requires_json() {
+        let human = Cli::try_parse_from(["rustywind", "--quiet", "--dry-run", "input.html"])
+            .expect("post-parse validation owns the conditional conflict");
+        assert!(human.validate().is_err());
+
+        let json =
+            Cli::try_parse_from(["rustywind", "--quiet", "--dry-run", "--json", "input.html"])
+                .expect("JSON dry-run should parse");
+        assert!(json.validate().is_ok());
+    }
+
+    #[test]
+    fn read_input_exposes_acquisition_errors() {
+        use std::io::{Cursor, ErrorKind, Read};
+
+        struct FailingReader;
+
+        impl Read for FailingReader {
+            fn read(&mut self, _buffer: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(ErrorKind::BrokenPipe, "stdin failed"))
+            }
+        }
+
+        assert_eq!(super::read_input(Cursor::new("input")).unwrap(), "input");
+        assert_eq!(
+            super::read_input(FailingReader).unwrap_err().to_string(),
+            "stdin failed"
+        );
     }
 
     #[test]

--- a/rustywind-cli/src/options.rs
+++ b/rustywind-cli/src/options.rs
@@ -9,7 +9,6 @@ use rustywind_core::{RustyWind, SourceLanguage};
 use rustywind_vite::create_vite_sorter;
 use serde::Deserialize;
 use std::fs;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -18,13 +17,19 @@ use ahash::AHashSet as HashSet;
 
 use crate::Cli;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WriteMode {
     ToFile,
     DryRun,
     ToConsole,
     ToStdOut,
     CheckFormatted,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputFormat {
+    Human,
+    Json,
 }
 
 #[derive(Deserialize)]
@@ -96,7 +101,6 @@ impl From<CliSourceLanguage> for SourceLanguage {
 
 #[derive(Debug)]
 pub struct Options {
-    pub stdin: Option<String>,
     pub language: Option<SourceLanguage>,
     pub stdin_filename: Option<PathBuf>,
     pub rustywind: RustyWind,
@@ -105,21 +109,22 @@ pub struct Options {
     pub search_paths: Vec<PathBuf>,
     pub ignored_files: HashSet<PathBuf>,
     pub quiet: bool,
+    pub output_format: OutputFormat,
 }
 
 impl Options {
     pub fn new_from_cli(cli: Cli) -> Result<Options> {
-        let stdin = if cli.stdin {
-            let mut buffer = String::new();
-            let mut stdin = std::io::stdin(); // We get `Stdin` here.
-            stdin.read_to_string(&mut buffer).unwrap();
-            Some(buffer.to_string())
-        } else {
-            None
-        };
-
         let starting_paths = get_starting_path_from_cli(&cli);
-        let search_paths = get_search_paths_from_starting_paths(&starting_paths);
+        let output_format = if cli.json {
+            OutputFormat::Json
+        } else {
+            OutputFormat::Human
+        };
+        let search_paths = if output_format == OutputFormat::Human {
+            get_search_paths_from_starting_paths(&starting_paths)
+        } else {
+            Vec::new()
+        };
 
         let rustywind = RustyWind {
             regex: get_custom_regex_from_cli(&cli)?,
@@ -130,7 +135,6 @@ impl Options {
         };
 
         Ok(Options {
-            stdin,
             language: cli.language.map(Into::into),
             stdin_filename: cli.stdin_filename.clone(),
             rustywind,
@@ -139,6 +143,7 @@ impl Options {
             write_mode: get_write_mode_from_cli(&cli),
             ignored_files: get_ignored_files_from_cli(&cli),
             quiet: cli.quiet,
+            output_format,
         })
     }
 
@@ -230,6 +235,8 @@ fn get_write_mode_from_cli(cli: &Cli) -> WriteMode {
         WriteMode::CheckFormatted
     } else if cli.stdin {
         WriteMode::ToStdOut
+    } else if cli.json {
+        WriteMode::DryRun
     } else {
         WriteMode::ToConsole
     }

--- a/rustywind-cli/tests/json_output.rs
+++ b/rustywind-cli/tests/json_output.rs
@@ -1,0 +1,312 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn command(current_dir: &Path) -> Command {
+    let mut command = Command::new(assert_cmd::cargo::cargo_bin!("rustywind"));
+    command.current_dir(current_dir);
+    command
+}
+
+fn run(current_dir: &Path, args: &[&str]) -> Output {
+    command(current_dir)
+        .args(args)
+        .output()
+        .expect("rustywind should run")
+}
+
+fn run_with_stdin(current_dir: &Path, args: &[&str], stdin: &str) -> Output {
+    let mut child = command(current_dir)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("rustywind should start");
+    std::io::Write::write_all(
+        child.stdin.as_mut().expect("stdin should be piped"),
+        stdin.as_bytes(),
+    )
+    .expect("stdin should be written");
+    child.wait_with_output().expect("rustywind should finish")
+}
+
+fn json_stdout(output: &Output) -> Value {
+    assert!(output.stdout.ends_with(b"\n"));
+    assert!(!output.stdout[..output.stdout.len() - 1].contains(&b'\n'));
+    assert!(!output.stdout.ends_with(b"\n\n"));
+    serde_json::from_slice(&output.stdout[..output.stdout.len() - 1])
+        .expect("stdout should contain exactly one JSON document")
+}
+
+fn write_unsorted(path: impl AsRef<Path>) {
+    fs::write(path, r#"<div class="p-4 m-4"></div>"#).unwrap();
+}
+
+#[test]
+fn check_json_reports_changes_in_deterministic_order() {
+    let directory = TempDir::new().unwrap();
+    write_unsorted(directory.path().join("b.html"));
+    write_unsorted(directory.path().join("a.html"));
+
+    let output = run(directory.path(), &["--check-formatted", "--json", "."]);
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stderr.is_empty());
+    let json = json_stdout(&output);
+
+    assert_eq!(json["mode"], "check-formatted");
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["errors"], serde_json::json!([]));
+    // a `.` starting path displays as `./a.html` in human mode, and JSON reuses
+    // the human display algorithm
+    assert_eq!(
+        json["files_needing_formatting"],
+        serde_json::json!([
+            {"path":"./a.html","unsorted_classes":1},
+            {"path":"./b.html","unsorted_classes":1}
+        ])
+    );
+    assert!(json.get("proposed_changes").is_none());
+    assert!(json.get("written_files").is_none());
+}
+
+#[test]
+fn dry_run_and_bare_json_include_full_formatted_content() {
+    let directory = TempDir::new().unwrap();
+    write_unsorted(directory.path().join("input.html"));
+
+    for args in [
+        &["--dry-run", "--json", "input.html"][..],
+        &["--json", "input.html"][..],
+    ] {
+        let output = run(directory.path(), args);
+        assert_eq!(output.status.code(), Some(0));
+        assert!(output.stderr.is_empty());
+        let json = json_stdout(&output);
+
+        assert_eq!(json["mode"], "dry-run");
+        assert_eq!(json["ok"], false);
+        assert_eq!(
+            json["proposed_changes"],
+            serde_json::json!([{
+                "path":"input.html",
+                "content":r#"<div class="m-4 p-4"></div>"#
+            }])
+        );
+        assert!(json.get("written_files").is_none());
+    }
+
+    assert_eq!(
+        fs::read_to_string(directory.path().join("input.html")).unwrap(),
+        r#"<div class="p-4 m-4"></div>"#
+    );
+}
+
+#[test]
+fn write_json_reports_and_applies_changes() {
+    let directory = TempDir::new().unwrap();
+    write_unsorted(directory.path().join("input.html"));
+
+    let output = run(directory.path(), &["--write", "--json", "input.html"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(output.stderr.is_empty());
+    let json = json_stdout(&output);
+
+    assert_eq!(json["mode"], "write");
+    assert_eq!(json["ok"], true);
+    assert_eq!(
+        json["files_needing_formatting"],
+        serde_json::json!([{"path":"input.html","unsorted_classes":1}])
+    );
+    assert_eq!(
+        json["written_files"],
+        serde_json::json!([{"path":"input.html"}])
+    );
+    assert!(json.get("proposed_changes").is_none());
+    assert_eq!(
+        fs::read_to_string(directory.path().join("input.html")).unwrap(),
+        r#"<div class="m-4 p-4"></div>"#
+    );
+}
+
+#[test]
+fn stdin_json_reports_formatted_content_without_human_warning() {
+    let directory = TempDir::new().unwrap();
+    let output = run_with_stdin(
+        directory.path(),
+        &["--stdin", "--json"],
+        r#"<div class="p-4 m-4"></div>"#,
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert!(output.stderr.is_empty());
+    let json = json_stdout(&output);
+
+    assert_eq!(
+        json,
+        serde_json::json!({
+            "mode":"stdin",
+            "ok":false,
+            "unsorted_classes":1,
+            "content":r#"<div class="m-4 p-4"></div>"#,
+            "errors":[]
+        })
+    );
+
+    let no_classes = run_with_stdin(directory.path(), &["--stdin", "--json"], "plain text");
+    assert_eq!(no_classes.status.code(), Some(0));
+    assert!(no_classes.stderr.is_empty());
+    assert_eq!(json_stdout(&no_classes)["content"], "plain text");
+}
+
+#[test]
+fn json_continues_after_missing_input_and_returns_partial_results() {
+    let directory = TempDir::new().unwrap();
+    write_unsorted(directory.path().join("valid.html"));
+
+    let output = run(
+        directory.path(),
+        &["--dry-run", "--json", "valid.html", "missing.html"],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stderr.is_empty());
+    let json = json_stdout(&output);
+
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["files_needing_formatting"][0]["path"], "valid.html");
+    assert_eq!(json["proposed_changes"][0]["path"], "valid.html");
+    assert_eq!(json["errors"][0]["path"], "missing.html");
+    assert!(
+        json["errors"][0]["message"]
+            .as_str()
+            .is_some_and(|message| !message.is_empty())
+    );
+}
+
+#[test]
+fn missing_directory_is_a_walk_error() {
+    let directory = TempDir::new().unwrap();
+    let output = run(
+        directory.path(),
+        &["--check-formatted", "--json", "missing-directory"],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stderr.is_empty());
+    let json = json_stdout(&output);
+
+    assert_eq!(json["files_needing_formatting"], serde_json::json!([]));
+    assert_eq!(json["errors"][0]["path"], "missing-directory");
+}
+
+#[test]
+fn invalid_utf8_is_skipped_without_an_error() {
+    let directory = TempDir::new().unwrap();
+    fs::write(directory.path().join("binary.html"), [0xff, 0xfe]).unwrap();
+
+    let output = run(
+        directory.path(),
+        &["--check-formatted", "--json", "binary.html"],
+    );
+    assert_eq!(output.status.code(), Some(0));
+    assert!(output.stderr.is_empty());
+    let json = json_stdout(&output);
+
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["files_needing_formatting"], serde_json::json!([]));
+    assert_eq!(json["errors"], serde_json::json!([]));
+}
+
+#[test]
+fn overlapping_paths_are_processed_once() {
+    let directory = TempDir::new().unwrap();
+    fs::create_dir(directory.path().join("nested")).unwrap();
+    write_unsorted(directory.path().join("nested/input.html"));
+
+    let output = run(
+        directory.path(),
+        &["--dry-run", "--json", ".", "nested/input.html"],
+    );
+    assert_eq!(output.status.code(), Some(0));
+    let json = json_stdout(&output);
+
+    assert_eq!(
+        json["files_needing_formatting"].as_array().unwrap().len(),
+        1
+    );
+    assert_eq!(json["proposed_changes"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn colliding_human_paths_fall_back_to_cwd_relative_paths() {
+    let directory = TempDir::new().unwrap();
+    for root in ["left/src", "right/src"] {
+        fs::create_dir_all(directory.path().join(root)).unwrap();
+        write_unsorted(directory.path().join(root).join("input.html"));
+    }
+
+    let output = run(
+        directory.path(),
+        &["--dry-run", "--json", "left/src", "right/src"],
+    );
+    assert_eq!(output.status.code(), Some(0));
+    let json = json_stdout(&output);
+    let paths = json["files_needing_formatting"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["path"].as_str().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(paths, ["left/src/input.html", "right/src/input.html"]);
+    assert_eq!(json["proposed_changes"][0]["path"], paths[0]);
+    assert_eq!(json["proposed_changes"][1]["path"], paths[1]);
+}
+
+#[test]
+fn quiet_dry_run_is_allowed_only_for_json() {
+    let directory = TempDir::new().unwrap();
+    write_unsorted(directory.path().join("input.html"));
+
+    let json = run(
+        directory.path(),
+        &["--quiet", "--dry-run", "--json", "input.html"],
+    );
+    assert_eq!(json.status.code(), Some(0));
+    json_stdout(&json);
+
+    let human = run(directory.path(), &["--quiet", "--dry-run", "input.html"]);
+    assert_eq!(human.status.code(), Some(2));
+    assert!(human.stdout.is_empty());
+    assert!(!human.stderr.is_empty());
+}
+
+#[test]
+fn representative_human_modes_keep_their_output() {
+    let directory = TempDir::new().unwrap();
+    write_unsorted(directory.path().join("input.html"));
+
+    let dry_run = run(directory.path(), &["--dry-run", "input.html"]);
+    assert_eq!(dry_run.status.code(), Some(0));
+    assert_eq!(
+        String::from_utf8(dry_run.stdout).unwrap(),
+        "\ndry run mode activated: here is a list of files that would be changed when you run with the --write flag\n  * input.html\n"
+    );
+
+    let check = run(directory.path(), &["--check-formatted", "input.html"]);
+    assert_eq!(check.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8(check.stdout).unwrap(),
+        "\nonly printing changed files\n"
+    );
+    assert_eq!(
+        String::from_utf8(check.stderr).unwrap(),
+        "  * [UNFORMATTED FILE] input.html\n"
+    );
+
+    let stdin = run_with_stdin(directory.path(), &["--stdin"], "plain text");
+    assert_eq!(stdin.status.code(), Some(0));
+    assert_eq!(stdin.stdout, b"plain text");
+    assert_eq!(stdin.stderr, b"[WARN] No classes were found in STDIN");
+}

--- a/rustywind-cli/tests/json_output.rs
+++ b/rustywind-cli/tests/json_output.rs
@@ -1,4 +1,3 @@
-use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
@@ -6,26 +5,17 @@ use std::process::{Command, Output, Stdio};
 use serde_json::Value;
 use tempfile::TempDir;
 
-fn command(current_dir: &Path) -> Command {
-    let binary = assert_cmd::cargo::cargo_bin!("rustywind");
-    let mut command = target_command(binary, std::env::var_os("CROSS_TARGET_RUNNER"));
-    command.current_dir(current_dir);
-    command
+// cross runs the test harness itself under qemu, which cannot reliably spawn the
+// target binary as a child process, so these end-to-end tests only run on a
+// native target. cross sets `CROSS_RUNNER` inside its container; the tests.yml
+// job exercises the same tests natively on x86_64 Linux, macOS, and Windows
+fn emulated_under_cross() -> bool {
+    std::env::var_os("CROSS_RUNNER").is_some()
 }
 
-fn target_command(binary: &Path, runner: Option<OsString>) -> Command {
-    let Some(runner) = runner else {
-        return Command::new(binary);
-    };
-    let runner = runner
-        .into_string()
-        .expect("target runner should be valid Unicode");
-    let parts = shlex::split(&runner).expect("target runner should have valid shell quoting");
-    let Some((program, args)) = parts.split_first() else {
-        panic!("target runner should not be empty");
-    };
-    let mut command = Command::new(program);
-    command.args(args).arg(binary);
+fn command(current_dir: &Path) -> Command {
+    let mut command = Command::new(assert_cmd::cargo::cargo_bin!("rustywind"));
+    command.current_dir(current_dir);
     command
 }
 
@@ -65,25 +55,10 @@ fn write_unsorted(path: impl AsRef<Path>) {
 }
 
 #[test]
-fn target_command_wraps_binary_with_configured_runner() {
-    let command = target_command(
-        Path::new("/target/debug/rustywind"),
-        Some(OsString::from("/linux-runner aarch64 'runner option'")),
-    );
-
-    assert_eq!(command.get_program(), OsStr::new("/linux-runner"));
-    assert_eq!(
-        command.get_args().collect::<Vec<_>>(),
-        [
-            OsStr::new("aarch64"),
-            OsStr::new("runner option"),
-            OsStr::new("/target/debug/rustywind")
-        ]
-    );
-}
-
-#[test]
 fn check_json_reports_changes_in_deterministic_order() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     write_unsorted(directory.path().join("b.html"));
     write_unsorted(directory.path().join("a.html"));
@@ -111,6 +86,9 @@ fn check_json_reports_changes_in_deterministic_order() {
 
 #[test]
 fn dry_run_and_bare_json_include_full_formatted_content() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     write_unsorted(directory.path().join("input.html"));
 
@@ -143,6 +121,9 @@ fn dry_run_and_bare_json_include_full_formatted_content() {
 
 #[test]
 fn write_json_reports_and_applies_changes() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     write_unsorted(directory.path().join("input.html"));
 
@@ -170,6 +151,9 @@ fn write_json_reports_and_applies_changes() {
 
 #[test]
 fn stdin_json_reports_formatted_content_without_human_warning() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     let output = run_with_stdin(
         directory.path(),
@@ -199,6 +183,9 @@ fn stdin_json_reports_formatted_content_without_human_warning() {
 
 #[test]
 fn json_continues_after_missing_input_and_returns_partial_results() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     write_unsorted(directory.path().join("valid.html"));
 
@@ -223,6 +210,9 @@ fn json_continues_after_missing_input_and_returns_partial_results() {
 
 #[test]
 fn missing_directory_is_a_walk_error() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     let output = run(
         directory.path(),
@@ -238,6 +228,9 @@ fn missing_directory_is_a_walk_error() {
 
 #[test]
 fn invalid_utf8_is_skipped_without_an_error() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     fs::write(directory.path().join("binary.html"), [0xff, 0xfe]).unwrap();
 
@@ -256,6 +249,9 @@ fn invalid_utf8_is_skipped_without_an_error() {
 
 #[test]
 fn overlapping_paths_are_processed_once() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     fs::create_dir(directory.path().join("nested")).unwrap();
     write_unsorted(directory.path().join("nested/input.html"));
@@ -276,6 +272,9 @@ fn overlapping_paths_are_processed_once() {
 
 #[test]
 fn colliding_human_paths_fall_back_to_cwd_relative_paths() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     for root in ["left/src", "right/src"] {
         fs::create_dir_all(directory.path().join(root)).unwrap();
@@ -302,6 +301,9 @@ fn colliding_human_paths_fall_back_to_cwd_relative_paths() {
 
 #[test]
 fn quiet_dry_run_is_allowed_only_for_json() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     write_unsorted(directory.path().join("input.html"));
 
@@ -320,6 +322,9 @@ fn quiet_dry_run_is_allowed_only_for_json() {
 
 #[test]
 fn representative_human_modes_keep_their_output() {
+    if emulated_under_cross() {
+        return;
+    }
     let directory = TempDir::new().unwrap();
     write_unsorted(directory.path().join("input.html"));
 

--- a/rustywind-cli/tests/json_output.rs
+++ b/rustywind-cli/tests/json_output.rs
@@ -1,3 +1,4 @@
+use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
@@ -6,8 +7,25 @@ use serde_json::Value;
 use tempfile::TempDir;
 
 fn command(current_dir: &Path) -> Command {
-    let mut command = Command::new(assert_cmd::cargo::cargo_bin!("rustywind"));
+    let binary = assert_cmd::cargo::cargo_bin!("rustywind");
+    let mut command = target_command(binary, std::env::var_os("CROSS_TARGET_RUNNER"));
     command.current_dir(current_dir);
+    command
+}
+
+fn target_command(binary: &Path, runner: Option<OsString>) -> Command {
+    let Some(runner) = runner else {
+        return Command::new(binary);
+    };
+    let runner = runner
+        .into_string()
+        .expect("target runner should be valid Unicode");
+    let parts = shlex::split(&runner).expect("target runner should have valid shell quoting");
+    let Some((program, args)) = parts.split_first() else {
+        panic!("target runner should not be empty");
+    };
+    let mut command = Command::new(program);
+    command.args(args).arg(binary);
     command
 }
 
@@ -44,6 +62,24 @@ fn json_stdout(output: &Output) -> Value {
 
 fn write_unsorted(path: impl AsRef<Path>) {
     fs::write(path, r#"<div class="p-4 m-4"></div>"#).unwrap();
+}
+
+#[test]
+fn target_command_wraps_binary_with_configured_runner() {
+    let command = target_command(
+        Path::new("/target/debug/rustywind"),
+        Some(OsString::from("/linux-runner aarch64 'runner option'")),
+    );
+
+    assert_eq!(command.get_program(), OsStr::new("/linux-runner"));
+    assert_eq!(
+        command.get_args().collect::<Vec<_>>(),
+        [
+            OsStr::new("aarch64"),
+            OsStr::new("runner option"),
+            OsStr::new("/target/debug/rustywind")
+        ]
+    );
 }
 
 #[test]

--- a/rustywind-core/CHANGELOG.md
+++ b/rustywind-core/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Add `SortReport` and `RustyWind::sort_document_with_report`, which return the
+  sorted contents together with the number of class groups (attribute values or
+  custom-regex captures) whose text changed; `sort_document` is now a thin
+  wrapper over the report
+
 ## [0.5.0] - 2026-07-21
 
 ### Added

--- a/rustywind-core/src/app.rs
+++ b/rustywind-core/src/app.rs
@@ -38,6 +38,15 @@ enum SortableClassValue<'a> {
     Wrapped(WrappedClassList<'a>),
 }
 
+/// Result of sorting a source document
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SortReport<'a> {
+    /// Sorted source contents
+    pub contents: Cow<'a, str>,
+    /// Number of class groups whose final text changed
+    pub changed_class_groups: usize,
+}
+
 /// A validated comma-separated list of quoted static class tokens
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct WrappedClassList<'a> {
@@ -219,27 +228,45 @@ impl RustyWind {
     /// Embedded expressions are preserved byte-for-byte, and sorting or
     /// deduplication never crosses an expression boundary
     pub fn sort_document<'a>(&self, document: SourceDocument<'a>) -> Cow<'a, str> {
+        self.sort_document_with_report(document).contents
+    }
+
+    /// Sorts a language-aware source document and reports changed class groups
+    ///
+    /// A class group is one structured attribute value or one regular-expression
+    /// capture, regardless of how many static runs it contains
+    pub fn sort_document_with_report<'a>(&self, document: SourceDocument<'a>) -> SortReport<'a> {
         if matches!(self.regex, FinderRegex::DefaultRegex)
             && document.language().attribute_parser_profile().is_some()
         {
             return self.sort_structured_document(document);
         }
 
-        self.extraction_regex()
-            .replace_all(document.text(), |captures: &Captures| {
-                let Some(capture) = self.sortable_capture(captures, document) else {
-                    return captures[0].to_string();
-                };
+        let mut changed_class_groups = 0;
+        let contents =
+            self.extraction_regex()
+                .replace_all(document.text(), |captures: &Captures| {
+                    let Some(capture) = self.sortable_capture(captures, document) else {
+                        return captures[0].to_string();
+                    };
 
-                let sorted_classes =
-                    self.sort_source_value(capture.classes_match.as_str(), &capture.value);
-                splice_capture(
-                    capture.full_match.as_str(),
-                    &capture.full_match,
-                    &capture.classes_match,
-                    &sorted_classes,
-                )
-            })
+                    let sorted_classes =
+                        self.sort_source_value(capture.classes_match.as_str(), &capture.value);
+                    if sorted_classes != capture.classes_match.as_str() {
+                        changed_class_groups += 1;
+                    }
+                    splice_capture(
+                        capture.full_match.as_str(),
+                        &capture.full_match,
+                        &capture.classes_match,
+                        &sorted_classes,
+                    )
+                });
+
+        SortReport {
+            contents,
+            changed_class_groups,
+        }
     }
 
     /// Sorts a validated static class list and normalizes its whitespace
@@ -309,33 +336,44 @@ impl RustyWind {
         Some((range, value))
     }
 
-    fn sort_structured_document<'a>(&self, document: SourceDocument<'a>) -> Cow<'a, str> {
+    fn sort_structured_document<'a>(&self, document: SourceDocument<'a>) -> SortReport<'a> {
         let Some(attributes) = class_attributes(document) else {
-            return Cow::Borrowed(document.text());
+            return SortReport {
+                contents: Cow::Borrowed(document.text()),
+                changed_class_groups: 0,
+            };
         };
         let sortable = attributes
             .iter()
             .filter_map(|attribute| self.sortable_attribute(attribute, document))
             .collect::<Vec<_>>();
         if sortable.is_empty() {
-            return Cow::Borrowed(document.text());
+            return SortReport {
+                contents: Cow::Borrowed(document.text()),
+                changed_class_groups: 0,
+            };
         }
 
         let mut output = document.text().to_string();
-        let mut changed = false;
+        let mut changed_class_groups = 0;
         for (range, value) in sortable.into_iter().rev() {
             let original = &document.text()[range.clone()];
             let sorted = self.sort_source_value(original, &value);
             if sorted != original {
                 output.replace_range(range, &sorted);
-                changed = true;
+                changed_class_groups += 1;
             }
         }
 
-        if changed {
+        let contents = if changed_class_groups > 0 {
             Cow::Owned(output)
         } else {
             Cow::Borrowed(document.text())
+        };
+
+        SortReport {
+            contents,
+            changed_class_groups,
         }
     }
 
@@ -729,6 +767,118 @@ mod tests {
             app.sort_document(SourceDocument::new(source, SourceLanguage::Unknown)),
             r#"<div class="m-4 flex p-4"></div>"#
         );
+    }
+
+    #[test]
+    fn report_keeps_unchanged_content_borrowed() {
+        let source = r#"<div class="m-4 flex p-4"></div>"#;
+        let report = RUSTYWIND_DEFAULT
+            .sort_document_with_report(SourceDocument::new(source, SourceLanguage::Html));
+
+        assert!(matches!(report.contents, Cow::Borrowed(_)));
+        assert_eq!(report.contents, source);
+        assert_eq!(report.changed_class_groups, 0);
+    }
+
+    #[test]
+    fn report_counts_one_changed_structured_attribute() {
+        let source = r#"<div class="p-4 m-4 flex"></div>"#;
+        let report = RUSTYWIND_DEFAULT
+            .sort_document_with_report(SourceDocument::new(source, SourceLanguage::Html));
+
+        assert_eq!(report.contents, r#"<div class="m-4 flex p-4"></div>"#);
+        assert_eq!(report.changed_class_groups, 1);
+    }
+
+    #[test]
+    fn report_counts_multiple_changed_structured_attributes() {
+        let source = r#"<div class="p-4 m-4"></div><span className="p-2 m-2"></span>"#;
+        let report = RUSTYWIND_DEFAULT
+            .sort_document_with_report(SourceDocument::new(source, SourceLanguage::Html));
+
+        assert_eq!(report.changed_class_groups, 2);
+    }
+
+    #[test]
+    fn report_counts_duplicate_removal_without_reordering() {
+        let source = r#"<div class="flex flex"></div>"#;
+        let report = RUSTYWIND_DEFAULT
+            .sort_document_with_report(SourceDocument::new(source, SourceLanguage::Html));
+
+        assert_eq!(report.contents, r#"<div class="flex"></div>"#);
+        assert_eq!(report.changed_class_groups, 1);
+    }
+
+    #[test]
+    fn report_counts_whitespace_normalization() {
+        let source = r#"<div class="  flex   p-4  "></div>"#;
+        let report = RUSTYWIND_DEFAULT
+            .sort_document_with_report(SourceDocument::new(source, SourceLanguage::Html));
+
+        assert_eq!(report.contents, r#"<div class="flex p-4"></div>"#);
+        assert_eq!(report.changed_class_groups, 1);
+    }
+
+    #[test]
+    fn report_counts_changed_template_static_runs_as_one_group() {
+        let source = r#"<div class="p-4 m-4 {active} p-2 m-2"></div>"#;
+        let report = RUSTYWIND_DEFAULT
+            .sort_document_with_report(SourceDocument::new(source, SourceLanguage::Svelte));
+
+        assert_eq!(
+            report.contents,
+            r#"<div class="m-4 p-4 {active} m-2 p-2"></div>"#
+        );
+        assert_eq!(report.changed_class_groups, 1);
+    }
+
+    #[test]
+    fn report_does_not_count_opaque_values() {
+        let source = r#"<div class="p-4 m-4 {missing"></div>"#;
+        let report = RUSTYWIND_DEFAULT
+            .sort_document_with_report(SourceDocument::new(source, SourceLanguage::Svelte));
+
+        assert_eq!(report.contents, source);
+        assert_eq!(report.changed_class_groups, 0);
+    }
+
+    #[test]
+    fn report_uses_structured_counting_for_jsx() {
+        let source = r#"<div className="p-4 m-4" />"#;
+        let report = RUSTYWIND_DEFAULT
+            .sort_document_with_report(SourceDocument::new(source, SourceLanguage::Jsx));
+
+        assert_eq!(report.contents, r#"<div className="m-4 p-4" />"#);
+        assert_eq!(report.changed_class_groups, 1);
+    }
+
+    #[test]
+    fn report_uses_regex_counting_for_profileless_languages() {
+        let source = r#"<div class="p-4 m-4"></div>"#;
+        let report = RUSTYWIND_DEFAULT
+            .sort_document_with_report(SourceDocument::new(source, SourceLanguage::Unknown));
+
+        assert_eq!(report.contents, r#"<div class="m-4 p-4"></div>"#);
+        assert_eq!(report.changed_class_groups, 1);
+    }
+
+    #[test]
+    fn report_uses_regex_counting_for_wrapped_custom_captures() {
+        let extractor = crate::sorter::CustomClassExtractor::new(
+            Regex::new(r#"classes\((?P<classes>[^)]*)\)"#).unwrap(),
+        )
+        .unwrap();
+        let app = RustyWind {
+            regex: FinderRegex::CustomRegex(extractor),
+            class_wrapping: ClassWrapping::CommaSingleQuotes,
+            ..RUSTYWIND_DEFAULT
+        };
+        let source = "classes('p-4', 'm-4')";
+        let report =
+            app.sort_document_with_report(SourceDocument::new(source, SourceLanguage::Unknown));
+
+        assert_eq!(report.contents, "classes('m-4', 'p-4')");
+        assert_eq!(report.changed_class_groups, 1);
     }
 
     #[test_case("data-class" ; "data attribute")]

--- a/rustywind-core/src/lib.rs
+++ b/rustywind-core/src/lib.rs
@@ -24,5 +24,5 @@ pub mod property_order;
 pub mod utility_map;
 pub mod variant_order;
 
-pub use app::{InvalidClassList, PlainClassList, RustyWind};
+pub use app::{InvalidClassList, PlainClassList, RustyWind, SortReport};
 pub use source::{SourceDocument, SourceLanguage};


### PR DESCRIPTION
Closes: #139 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added `--json` machine-readable output for check, preview, write, and stdin (including `--dry-run --json`).
  - Bare `--json` mode never writes files.
  - Added report support that returns the number of changed class groups during sorting.

- **Bug Fixes**
  - Unreadable stdin now produces a normal, standard error message.

- **Documentation**
  - Updated changelogs and CLI usage to explain `--json` output structure and exit-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->