### PR TITLE
Add `RustyWind::sort_class_value` for sorting bare class attribute values

### DIFF
--- a/rustywind-core/CHANGELOG.md
+++ b/rustywind-core/CHANGELOG.md
@@ -8,6 +8,9 @@
   sorted contents together with the number of class groups (attribute values or
   custom-regex captures) whose text changed; `sort_document` is now a thin
   wrapper over the report
+- Add `RustyWind::sort_class_value`, which sorts a bare class attribute value
+  with template awareness, for tools that locate class attributes with their
+  own parser and only need the value sorted
 
 ## [0.5.0] - 2026-07-21
 

--- a/rustywind-core/src/app.rs
+++ b/rustywind-core/src/app.rs
@@ -8,7 +8,8 @@ use crate::{
     markup_parser::is_attribute_name_character,
     sorter::{FinderRegex, Sorter},
     source::{
-        ClassValueAnalysis, SourceDocument, StaticRuns, analyze_class_value, is_plain_class_list,
+        ClassValueAnalysis, SourceDocument, SourceLanguage, StaticRuns, analyze_class_value,
+        is_plain_class_list,
     },
     tailwind_prefix::{normalize_tailwind_prefix, normalize_tailwind_prefix_value},
 };
@@ -274,8 +275,35 @@ impl RustyWind {
         self.sort_class_run(class_list.as_str())
     }
 
+    /// Sorts a bare class attribute value with template awareness
+    ///
+    /// Handles one value like [`RustyWind::sort_document`] handles the
+    /// attribute values it discovers itself, for tools that locate class
+    /// attributes with their own parser
+    pub fn sort_class_value<'a>(&self, value: &'a str, language: SourceLanguage) -> Cow<'a, str> {
+        match self.sortable_class_value(value, language) {
+            Some(sortable) => self.sort_source_value(value, &sortable),
+            None => Cow::Borrowed(value),
+        }
+    }
+
     fn extraction_regex(&self) -> &Regex {
         &self.regex
+    }
+
+    fn sortable_class_value<'a>(
+        &self,
+        value: &'a str,
+        language: SourceLanguage,
+    ) -> Option<SortableClassValue<'a>> {
+        if matches!(self.class_wrapping, ClassWrapping::NoWrapping) {
+            match analyze_class_value(value, language) {
+                ClassValueAnalysis::Sortable(runs) => Some(SortableClassValue::Static(runs)),
+                ClassValueAnalysis::Opaque => None,
+            }
+        } else {
+            WrappedClassList::parse(value, self.class_wrapping).map(SortableClassValue::Wrapped)
+        }
     }
 
     fn sortable_capture<'a>(
@@ -296,17 +324,7 @@ impl RustyWind {
             FinderRegex::CustomRegex(extractor) => extractor.classes(captures)?,
         };
 
-        let value = if matches!(self.class_wrapping, ClassWrapping::NoWrapping) {
-            match analyze_class_value(classes_match.as_str(), document.language()) {
-                ClassValueAnalysis::Sortable(runs) => SortableClassValue::Static(runs),
-                ClassValueAnalysis::Opaque => return None,
-            }
-        } else {
-            SortableClassValue::Wrapped(WrappedClassList::parse(
-                classes_match.as_str(),
-                self.class_wrapping,
-            )?)
-        };
+        let value = self.sortable_class_value(classes_match.as_str(), document.language())?;
 
         Some(SortableCapture {
             full_match,
@@ -321,17 +339,8 @@ impl RustyWind {
         document: SourceDocument<'a>,
     ) -> Option<(Range<usize>, SortableClassValue<'a>)> {
         let range = attribute.value_range();
-        let value = if matches!(self.class_wrapping, ClassWrapping::NoWrapping) {
-            match analyze_class_value(&document.text()[range.clone()], document.language()) {
-                ClassValueAnalysis::Sortable(runs) => SortableClassValue::Static(runs),
-                ClassValueAnalysis::Opaque => return None,
-            }
-        } else {
-            SortableClassValue::Wrapped(WrappedClassList::parse(
-                &document.text()[range.clone()],
-                self.class_wrapping,
-            )?)
-        };
+        let value =
+            self.sortable_class_value(&document.text()[range.clone()], document.language())?;
 
         Some((range, value))
     }

--- a/rustywind-core/tests/template_aware_sorting.rs
+++ b/rustywind-core/tests/template_aware_sorting.rs
@@ -725,3 +725,67 @@ fn plain_class_lists_reject_source_syntax_and_unbalanced_brackets() {
     let parsed = PlainClassList::parse(arbitrary).expect("balanced arbitrary values are static");
     assert_eq!(parsed.as_str(), arbitrary);
 }
+
+#[test]
+fn class_values_sort_static_runs_and_preserve_expressions() {
+    let sorter = RustyWind::default();
+
+    for (value, expected) in [
+        // Plain values sort like a static class list
+        ("p-4 flex m-4", "m-4 flex p-4"),
+        // Static runs on each side of an expression sort independently
+        (
+            "text-white p-4 {% if active %}flex{% endif %} bg-blue-700",
+            "p-4 text-white {% if active %}flex{% endif %} bg-blue-700",
+        ),
+        // Expression-attached tokens are opaque and pin their position,
+        // while the static run before them still sorts
+        (
+            "gap-2 badge badge-{{ item.status|status_color }} whitespace-nowrap",
+            "badge gap-2 badge-{{ item.status|status_color }} whitespace-nowrap",
+        ),
+        // Duplicates are removed within a run but never across an expression
+        (
+            "p-4 m-4 p-4 {{ extra }} p-4 m-4 p-4",
+            "m-4 p-4 {{ extra }} m-4 p-4",
+        ),
+        // Fully dynamic values are returned unchanged
+        ("{{ button_classes }}", "{{ button_classes }}"),
+        // Malformed template syntax is left alone rather than scrambled
+        ("p-4 {{ unclosed", "p-4 {{ unclosed"),
+    ] {
+        assert_eq!(
+            sorter.sort_class_value(value, SourceLanguage::Django),
+            expected
+        );
+    }
+}
+
+#[test]
+fn class_values_follow_the_configured_wrapping() {
+    let sorter = RustyWind {
+        class_wrapping: ClassWrapping::CommaSingleQuotes,
+        ..RustyWind::default()
+    };
+
+    assert_eq!(
+        sorter.sort_class_value("'p-4', 'flex', 'm-4'", SourceLanguage::Django),
+        "'m-4', 'flex', 'p-4'"
+    );
+}
+
+#[test]
+fn class_value_sorting_matches_document_sorting() {
+    let sorter = RustyWind::default();
+    let value = "input validator {% if field.errors %}input-error{% endif %} w-full {{ class }}";
+    let document = format!(r#"<div class="{value}"></div>"#);
+
+    let document_sorted =
+        sorter.sort_document(SourceDocument::new(&document, SourceLanguage::Django));
+    let value_sorted = sorter.sort_class_value(value, SourceLanguage::Django);
+
+    assert_eq!(
+        document_sorted.into_owned(),
+        format!(r#"<div class="{value_sorted}"></div>"#)
+    );
+}


### PR DESCRIPTION
Hi !

I'm trying to integrate rustywind to [djangofmt](https://github.com/UnknownPlatypus/djangofmt/pull/332) and was needing an api to format a class content directly, respecting the template language

I've added an api for that and updated existing code to reuse it.

Let me know what you think

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sorting standalone class attribute values with template-aware handling.
  * Preserves template expressions while sorting static classes and removes local duplicates.
  * Supports configured class wrapping and multiple source languages.

* **Bug Fixes**
  * Improved handling of dynamic and malformed class values.

* **Documentation**
  * Documented the new class-value sorting capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->