### PR TITLE
perf: Also cache negative lookups in `HybridSorter::get_sort_key`

### DIFF
--- a/rustywind-core/src/hybrid_sorter.rs
+++ b/rustywind-core/src/hybrid_sorter.rs
@@ -39,7 +39,9 @@ pub struct HybridSorter {
     /// LRU cache for dynamically computed sort keys
     /// Capacity: DEFAULT_CACHE_SIZE entries (covers most real-world usage)
     /// Uses CompactString keys for memory efficiency (24 bytes inline, no heap for typical classes)
-    cache: Arc<Cache<compact_str::CompactString, SortKey>>,
+    /// Stores `None` for unknown classes too: re-running the exhaustive pattern scan for every
+    /// occurrence of a non-Tailwind class dominates sorting time on real-world files.
+    cache: Arc<Cache<compact_str::CompactString, Option<SortKey>>>,
 }
 
 impl HybridSorter {
@@ -110,19 +112,15 @@ impl HybridSorter {
         // tier 1: check LRU cache for previously computed classes (fast)
         // CompactString has efficient conversion from &str
         let class_compact = compact_str::CompactString::new(class);
-        if let Some(cached_key) = self.cache.get(&class_compact) {
-            return Some(cached_key);
+        if let Some(cached) = self.cache.get(&class_compact) {
+            return cached;
         }
 
-        // tier 2: compute using pattern sorter and cache the result
-        if let Some(sort_key) = self.pattern_sorter.get_sort_key(class) {
-            // cache the computed result for future lookups
-            // CompactString stores most classes inline (24 bytes) avoiding heap allocations
-            self.cache.insert(class_compact, sort_key.clone());
-            return Some(sort_key);
-        }
-
-        None
+        // tier 2: compute using pattern sorter and cache the result, negative outcomes included
+        // CompactString stores most classes inline (24 bytes) avoiding heap allocations
+        let sort_key = self.pattern_sorter.get_sort_key(class);
+        self.cache.insert(class_compact, sort_key.clone());
+        sort_key
     }
 
     /// Sort a list of Tailwind CSS classes according to the canonical ordering
@@ -256,6 +254,18 @@ mod tests {
         let key2 = sorter.get_sort_key("m-4").unwrap();
 
         assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn test_unknown_classes_are_cached() {
+        let sorter = HybridSorter::new();
+
+        assert!(sorter.get_sort_key("not-a-tailwind-class").is_none());
+
+        // the negative result is cached so repeat lookups skip the pattern scan
+        let (entries, _) = sorter.cache_stats();
+        assert_eq!(entries, 1);
+        assert!(sorter.get_sort_key("not-a-tailwind-class").is_none());
     }
 
     #[test]

--- a/rustywind-core/src/hybrid_sorter.rs
+++ b/rustywind-core/src/hybrid_sorter.rs
@@ -25,7 +25,7 @@ use quick_cache::sync::Cache;
 
 use crate::pattern_sorter::{PatternSorter, SortKey};
 
-pub const DEFAULT_CACHE_SIZE: usize = 7500;
+pub const DEFAULT_CACHE_SIZE: usize = 10_000;
 
 /// Hybrid sorter combining LRU cache and pattern-based sorting
 ///
@@ -45,7 +45,7 @@ pub struct HybridSorter {
 }
 
 impl HybridSorter {
-    /// Create a new hybrid sorter with default cache size (5000 entries)
+    /// Create a new hybrid sorter with the default cache size ([`DEFAULT_CACHE_SIZE`])
     pub fn new() -> Self {
         Self::with_cache_size(DEFAULT_CACHE_SIZE)
     }


### PR DESCRIPTION
## What it does

`HybridSorter::get_sort_key` currently only caches *successful* lookups. 
A class not recognized as a Tailwind utility is never cached a we re-pay the full pattern scan each time.

This turns out to be a dominant cost, especially for template with mixed tailwind and non tailwind classes (quite usual for legacy codebase or ones extending tailwind to build a design system for ex with https://daisyui.com/)

I've also bumped the cache key size since we now expect more possible values
## Numbers

Measured with CodSpeed (simulation mode) while integrating `rustywind_core` into djangofmt's linter (https://github.com/UnknownPlatypus/djangofmt/pull/332#issuecomment-4605326120), sorting `class` attributes of real-world templates where most classes are **not** Tailwind utilities:

| Template (lint pass incl. sorting every `class` attr) | Before | After | Speedup |
|---|---|---|---|
| Zulip `comparison_table_integrated.html` (1,805 class attrs, 3,428 tokens, heavily repeated) | 15.3 ms | 4.7 ms | **×3.3** |
| Django `strip_tags1.html` (609 class attrs, 1,452 tokens) | 7.3 ms | 3.2 ms | **×2.3** |
| makeplane `project_invitation.html` | 637 µs | 458 µs | +39% |
| Zulip `upgrade.html` | 634 µs | 495 µs | +28% |

Flamegraphs before the change showed ~33% of total lint time in `memcmp`/`is_prefix_of`/`equal_same_length` alone, all under repeated `UtilityMap::match_pattern` scans for the same unknown classes (e.g. `icon icon-check` appearing 494× in one file).

Also tested with hyperfine on my work codebase (2,654 Django templates, ~17 MB, mixed Tailwind/custom classes because legacy that is now mostly using tailwind): **It went from ~60 ms to ~24 ms**

I'm also trying another optimization inspired by ruff isort with a [precomputed key struct](https://github.com/astral-sh/ruff/blob/24baf2cd8fd7a191625e7029d91a45a56dda9b85/crates/ruff_linter/src/rules/isort/sorting.rs#L83-L96) to avoid any allocations in comparisons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved sorting efficiency by caching both recognized and unrecognized class results.
  * Increased the default cache capacity to support more cached entries.
* **Bug Fixes**
  * Repeated lookups for unknown classes now use cached results, avoiding unnecessary reprocessing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->