### PR TITLE
Add a `runtime-rng` feature so wasm builds can opt out of `getrandom`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ quick_cache = "0.7"
 compact_str = "0.10"
 
 # hashmap
-ahash = "0.8"
+# Lowest common denominator: the `runtime-rng` default needs getrandom, which doesn't build
+# on wasm32-unknown-unknown. Members that want stock ahash re-enable default features.
+ahash = { version = "0.8", default-features = false, features = ["std", "no-rng"] }
 
 # errors
 eyre = "0.6"

--- a/rustywind-cli/Cargo.toml
+++ b/rustywind-cli/Cargo.toml
@@ -22,7 +22,7 @@ rustywind_vite = { path = "../rustywind-vite", version = "=0.6.0" }
 # utils
 regex = { workspace = true }
 once_cell = { workspace = true }
-ahash = { workspace = true }
+ahash = { workspace = true, features = ["runtime-rng"] }
 
 # logging
 env_logger = { workspace = true }

--- a/rustywind-core/Cargo.toml
+++ b/rustywind-core/Cargo.toml
@@ -9,6 +9,12 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[features]
+default = ["runtime-rng"]
+# Keep the default unless you target wasm32-unknown-unknown,
+# where this feature's getrandom dependency doesn't build.
+runtime-rng = ["ahash/runtime-rng"]
+
 [dependencies]
 once_cell = { workspace = true }
 quick_cache = { workspace = true }


### PR DESCRIPTION
ahash's default `runtime-rng` feature pulls in getrandom for random hash seeds.
getrandom has no randomness source on `wasm32-unknown-unknown` and fails with a `compile_error!` unless the **top-level** crate opts into a backend (its `wasm_js` feature). 

This makes `rustywind_core` unbuildable for the browser out of the box: every downstream wasm user has to declare a phantom getrandom dependency just to flip that feature, and keep its major version in lockstep with ahash's, or the
feature silently lands on the wrong getrandom copy.

This PR forwards the choice instead:

- new `runtime-rng` feature on `rustywind_core`, **on by default** and forwarding to `ahash/runtime-rng`, existing users are unaffected.
- wasm users build with `default-features = false`, dropping getrandom entirely; ahash then falls back to fixed hash keys (`no-rng`), which only gives up HashDoS resistance on internal class-lookup maps.

This was breaking my integration in the djangofmt [playground](https://unknownplatypus.github.io/djangofmt/) and it's now building and working fine

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for WebAssembly builds by avoiding unsupported random-number generation features by default.
* **Configuration**
  * Added an opt-in runtime-randomness setting for environments that support it.
  * Preserved standard runtime-randomness behavior for command-line builds while allowing WebAssembly targets to disable incompatible functionality.
  * Improved portability without changing the default experience for supported native platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->